### PR TITLE
Adding support for automatic refresh of online status in poe.trade

### DIFF
--- a/POEApi.Model/Settings.cs
+++ b/POEApi.Model/Settings.cs
@@ -89,7 +89,13 @@ namespace POEApi.Model
 
         private static ShopSetting createShopSetting(XElement shop)
         {
-            return new ShopSetting { ThreadId = shop.Attribute("ThreadId").Value, ThreadTitle = shop.Attribute("ThreadTitle").Value };
+            string s = (string)shop.Attribute("PoeTradeURL");
+            if (s == null)
+            {
+                //Compatibility with old file without this attribute
+                s = "";
+            }
+            return new ShopSetting { ThreadId = shop.Attribute("ThreadId").Value, ThreadTitle = shop.Attribute("ThreadTitle").Value, PoeTradeURL = s};
         }
 
         private static string tryGetValue(XElement list, string key)
@@ -205,7 +211,10 @@ namespace POEApi.Model
 
                 foreach (var shop in ShopSettings)
                 {
-                    XElement buyout = new XElement("Shop", new XAttribute("League", shop.Key), new XAttribute("ThreadId", shop.Value.ThreadId), new XAttribute("ThreadTitle", shop.Value.ThreadTitle));
+                    XElement buyout = new XElement("Shop", new XAttribute("League", shop.Key), 
+                        new XAttribute("ThreadId", shop.Value.ThreadId), 
+                        new XAttribute("ThreadTitle", shop.Value.ThreadTitle) , 
+                        new XAttribute("PoeTradeURL", shop.Value.PoeTradeURL));
                     settingsFile.Element("ShopSettings").Add(buyout);
                 }
 

--- a/POEApi.Model/ShopSetting.cs
+++ b/POEApi.Model/ShopSetting.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Timers;
+using System.Net;
+using System.Collections.Specialized;
 
 namespace POEApi.Model
 {
@@ -9,5 +12,6 @@ namespace POEApi.Model
     {
         public string ThreadId { get; set; }
         public string ThreadTitle { get; set; }
+        public string PoeTradeURL { get; set; }
     }
 }

--- a/Procurement/Controls/TradeSettings.xaml
+++ b/Procurement/Controls/TradeSettings.xaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
+             d:DesignHeight="300" d:DesignWidth="800">
     <Border Grid.Column="0" BorderBrush="#FF76591B" BorderThickness="2" Background="Black">
         <Grid Width="950">
             <Grid.RowDefinitions>
@@ -13,6 +13,8 @@
                 <RowDefinition Height="25" />
                 <RowDefinition Height="25" />
                 <RowDefinition Height="28" />
+                <RowDefinition Height="28" />
+                <RowDefinition Height="45" />
                 <RowDefinition Height="28" />
                 <RowDefinition Height="28" />
                 <RowDefinition Height="*" />
@@ -25,27 +27,40 @@
             <CheckBox Grid.Row="2" Foreground="#FFAB9066" IsChecked="{Binding BuyoutItemsOnlyVisibleInBuyoutsTag}" Content="Buyouts items only visible in buyouts tag" HorizontalAlignment="Left" Margin="0,2,0,0" />
 
             <CheckBox Grid.Row="3" Foreground="#FFAB9066" IsChecked="{Binding OnlyDisplayBuyouts}" Content="Only display items with buyout" HorizontalAlignment="Left" Margin="0,2,0,0" />
-
+    
             <Grid Grid.Row="4">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="80"/>
+                    <ColumnDefinition Width="100"/>
                     <ColumnDefinition Width="100"/>
                 </Grid.ColumnDefinitions>
 
                 <Label Grid.Column="0" Content="Thread Id" Foreground="#FFAB9066" FontSize="12" />
-                <TextBox Height="22" Width="120" Grid.Column="1" Text="{Binding ThreadId}"  HorizontalAlignment="Left"  />
+                <TextBox Height="22" Width="100" Grid.Column="1" Text="{Binding ThreadId}"  HorizontalAlignment="Left"  />
             </Grid>
             <Grid Grid.Row="5">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="80"/>
+                    <ColumnDefinition Width="100"/>
                     <ColumnDefinition Width="800"/>
                 </Grid.ColumnDefinitions>
 
                 <Label Grid.Column="0" Content="Thread Title" Foreground="#FFAB9066" FontSize="12" />
                 <TextBox Height="22" Width="720" Grid.Column="1" Text="{Binding ThreadTitle}"  HorizontalAlignment="Left" />
             </Grid>
+            <Label Grid.Row="6" Foreground="#FFAB9066" FontSize="12" Margin="0, 0, 0, 0">
+                <TextBlock>
+                    Enter your personal poe.trade URL and Procurement will automatically refresh your online status for you as long as it remains open.<LineBreak/>You can get your URL by sending a PM to 'poexyzis' on the game forums. (<Hyperlink Click="Hyperlink_Click">http://www.pathofexile.com/private-messages/compose/to/poexyzis</Hyperlink>)
+                </TextBlock>
+            </Label>
+            <Grid Grid.Row="7">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="100"/>
+                    <ColumnDefinition Width="800"/>
+                </Grid.ColumnDefinitions>
 
-            <Button Grid.Row="6" Content="Save Thread Settings" Height="22" Width="120" Style="{Binding}" HorizontalAlignment="Left" Margin="10,0,0,0" Command="{Binding SaveCommand}"/>
+                <Label Grid.Column="0" Content="Poe.trade URL" Foreground="#FFAB9066" FontSize="12" />
+                <TextBox Height="22" Width="720" Grid.Column="1" Text="{Binding PoeTradeURL}"  HorizontalAlignment="Left" />
+            </Grid>
+            <Button Grid.Row="8" Content="Save Thread Settings" Style="{Binding}" Height="22" Width="120" HorizontalAlignment="Left" Margin="10,0,0,0" Command="{Binding SaveCommand}"/>
         </Grid>
     </Border>
 </UserControl>

--- a/Procurement/Controls/TradeSettings.xaml.cs
+++ b/Procurement/Controls/TradeSettings.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Procurement.ViewModel;
 using System.Windows.Controls;
+using System.Diagnostics;
 
 namespace Procurement.Controls
 {
@@ -9,6 +10,11 @@ namespace Procurement.Controls
         {
             InitializeComponent();
             this.DataContext = new TradeSettingsViewModel();
+        }
+
+        private void Hyperlink_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            Process.Start("http://www.pathofexile.com/private-messages/compose/to/poexyzis");
         }
     }
 }

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Utility\CharacterTabInjector.cs" />
     <Compile Include="Utility\ExportPreferenceManager.cs" />
     <Compile Include="Utility\ItemHoverRenderer.cs" />
+    <Compile Include="Utility\PoeTradeOnlineHelper.cs" />
     <Compile Include="Utility\StashHelper.cs" />
     <Compile Include="Utility\VersionChecker.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CraftedModFilter.cs" />

--- a/Procurement/Utility/PoeTradeOnlineHelper.cs
+++ b/Procurement/Utility/PoeTradeOnlineHelper.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Timers;
+using System.Net;
+using System.Collections.Specialized;
+using POEApi.Model;
+
+namespace Procurement.Utility
+{
+    class PoeTradeOnlineHelper
+    {
+        private static PoeTradeOnlineHelper instance;
+
+        private System.Timers.Timer refreshTimer;
+        private HashSet<ShopSetting> shopSettings;
+        private Dictionary<WebClient, ShopSetting> mapping;
+
+        private PoeTradeOnlineHelper()
+        {
+            refreshTimer = new Timer();
+            refreshTimer.Elapsed += new ElapsedEventHandler(OnTimedEvent);
+            refreshTimer.Interval = 30 * 60 * 1000; //Refresh every half an hour to be sure
+            refreshTimer.Enabled = true;
+
+            shopSettings = new HashSet<ShopSetting>();
+            mapping = new Dictionary<WebClient, ShopSetting>();
+        }
+
+        public void RegisterForOnlineRefresh(List<ShopSetting> shopSettings)
+        {
+            foreach (ShopSetting shopSetting in shopSettings)
+            {
+                RegisterForOnlineRefresh(shopSetting);
+            }
+        }
+
+        public void RegisterForOnlineRefresh(ShopSetting shopSetting)
+        {
+            shopSettings.Add(shopSetting);
+            //Refresh just the new one
+            RefreshOnlineStatus(shopSetting);
+        }
+
+        public void UnregisterForOnlineRefresh(ShopSetting shopSetting)
+        {
+            shopSettings.Remove(shopSetting);
+        }
+
+        public static PoeTradeOnlineHelper Instance
+        {
+            get 
+            {
+                if (instance == null)
+                {
+                    instance = new PoeTradeOnlineHelper();
+                }
+                return instance;
+            }
+        }
+
+        private void OnTimedEvent(object source, ElapsedEventArgs e)
+        {
+            Console.WriteLine("Refreshing online status...");
+            foreach (ShopSetting shopSetting in shopSettings)
+            {
+                RefreshOnlineStatus(shopSetting);
+            }
+        }
+
+        private void RefreshOnlineStatus(ShopSetting shopSetting)
+        {
+            if (shopSetting.PoeTradeURL != null && shopSetting.PoeTradeURL.Length > 0)
+            {
+                Uri refreshUri = new Uri(shopSetting.PoeTradeURL);
+                using (var client = new WebClient())
+                {
+                    var data = new NameValueCollection();
+                    client.UploadValuesAsync(new Uri(shopSetting.PoeTradeURL), "POST", data);
+                    client.UploadValuesCompleted += client_UploadValuesCompleted;
+                    mapping[client] = shopSetting;
+                }
+            }
+        }
+
+        private void client_UploadValuesCompleted(object sender, UploadValuesCompletedEventArgs e)
+        {
+            ShopSetting shopSetting = mapping[(WebClient)sender];
+            mapping.Remove((WebClient)sender);
+
+            Console.WriteLine("Successfully refreshed online status for " + shopSetting.PoeTradeURL);
+        }
+
+    }
+
+}

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -98,6 +98,7 @@ namespace Procurement.ViewModel
             statusController.DisplayMessage(ApplicationState.Version + " Initialized.\r");
 
             VersionChecker.CheckForUpdates();
+            PoeTradeOnlineHelper.Instance.RegisterForOnlineRefresh(Settings.ShopSettings.Values.ToList());
         }
 
         void txtPassword_PasswordChanged(object sender, System.Windows.RoutedEventArgs e)

--- a/Procurement/ViewModel/TradeSettingsViewModel.cs
+++ b/Procurement/ViewModel/TradeSettingsViewModel.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
+using Procurement.Utility;
 
 namespace Procurement.ViewModel
 {
@@ -88,6 +89,18 @@ namespace Procurement.ViewModel
             }
         }
 
+        private string poeTradeURL;
+        public string PoeTradeURL
+        {
+            get { return poeTradeURL; }
+            set
+            {
+                poeTradeURL = value;
+                if (PropertyChanged != null)
+                    PropertyChanged(this, new PropertyChangedEventArgs("PoeTradeURL"));
+            }
+        }
+
         public TradeSettingsViewModel()
         {
             this.embedBuyouts = getSetting(EMBED_BUYOUTS);
@@ -101,6 +114,7 @@ namespace Procurement.ViewModel
 
             this.threadId = Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId;
             this.threadTitle = Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle;
+            this.poeTradeURL = Settings.ShopSettings[ApplicationState.CurrentLeague].PoeTradeURL;
         }
 
         private void saveShopSettings(object obj)
@@ -110,6 +124,10 @@ namespace Procurement.ViewModel
             
             Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId = this.threadId;
             Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle = this.threadTitle;
+            Settings.ShopSettings[ApplicationState.CurrentLeague].PoeTradeURL = this.poeTradeURL;
+
+            //Notify about the update in case the URL changed
+            PoeTradeOnlineHelper.Instance.RegisterForOnlineRefresh(Settings.ShopSettings[ApplicationState.CurrentLeague]);
 
             if (Settings.SaveShopSettings())
                 MessageBox.Show("Shop settings saved", "Settings saved", MessageBoxButton.OK, MessageBoxImage.Information);


### PR DESCRIPTION
I added a small feature that helps the user keep his user online in poe.trade/poe.xyz for as long as he keeps Procurement open. Hoping you'll like it and merge it.

Disclaimer: my c# might be a bit rusty, let me know if you need me to clean something up