### PR TITLE
Changed error text from DebugLog.log to DebugInfo.log

### DIFF
--- a/POEApi.Model/POEModel.cs
+++ b/POEApi.Model/POEModel.cs
@@ -120,7 +120,7 @@ namespace POEApi.Model
                 Logger.Log(ex);
             }
 
-            throw new Exception(@"Downloading stash, details logged to DebugLog.log, please open a ticket at https://github.com/Stickymaddness/Procurement/issues");
+            throw new Exception(@"Downloading stash, details logged to DebugInfo.log, please open a ticket at https://github.com/Stickymaddness/Procurement/issues");
         }
 
         public Stash GetStash(string league)
@@ -163,7 +163,7 @@ namespace POEApi.Model
             catch (Exception ex)
             {
                 Logger.Log(string.Format("Error downloading stash for {0}, exception details: {1}", league, ex.ToString()));
-                throw new Exception(@"Downloading stash for " + league + ", details logged to DebugLog.log, please open a ticket at https://github.com/Stickymaddness/Procurement/issues");
+                throw new Exception(@"Downloading stash for " + league + ", details logged to DebugInfo.log, please open a ticket at https://github.com/Stickymaddness/Procurement/issues");
             }
         }
 


### PR DESCRIPTION
Simple change to the name of the file in an error message to match the actual name of the file.
