### PR TITLE
Added "Advanced Search" filtering

### DIFF
--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Utility\ItemHoverRenderer.cs" />
     <Compile Include="Utility\StashHelper.cs" />
     <Compile Include="Utility\VersionChecker.cs" />
+    <Compile Include="ViewModel\AdvancedSearchCategory.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\AccurayFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CraftedModFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CurrencyFilter.cs" />

--- a/Procurement/View/StashView.xaml
+++ b/Procurement/View/StashView.xaml
@@ -223,8 +223,10 @@
                             <ScrollViewer VerticalScrollBarVisibility="Visible" CanContentScroll="True" Height="455">
                                 <Grid>
                                     <StackPanel>
+                                        <Label Content="Filter :" Foreground="#FFAB9066"/>
+                                        <TextBox Name="AdvancedSearchFilter" Foreground="#FFAB9066" Background="Black" KeyUp="AdvancedSearchFilter_KeyUp"></TextBox>
                                         <CheckBox Content="None" Foreground="#FFAB9066" Background="Black" Checked="CheckBox_Checked" />
-                                        <ItemsControl ItemsSource="{Binding AvailableCategories}">
+                                        <ItemsControl ItemsSource="{Binding AvailableCategories}" Name="AdvancedSearchItemControl">
                                             <ItemsControl.ItemsPanel>
                                                 <ItemsPanelTemplate>
                                                     <StackPanel Orientation="Vertical"/>
@@ -232,7 +234,7 @@
                                             </ItemsControl.ItemsPanel>
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <CheckBox Content="{Binding Key}" Foreground="#FFAB9066" Background="Black" Checked="CheckBox_Checked" Unchecked="CheckBox_Checked">
+                                                    <CheckBox Content="{Binding Key}" Foreground="#FFAB9066" Background="Black" Checked="CheckBox_Checked" Unchecked="CheckBox_Checked" IsChecked="{Binding IsChecked}" Visibility="{Binding IsVisibleString}">
                                                         <CheckBox.ToolTip>
                                                             <Border Background="Black" BorderBrush="#FFAB9066" BorderThickness="1">
                                                                 <TextBlock Text="{Binding Value}" Foreground="#FFAB9066" />

--- a/Procurement/View/StashView.xaml.cs
+++ b/Procurement/View/StashView.xaml.cs
@@ -34,5 +34,29 @@ namespace Procurement.View
 
             vm.SetCategoryFilter(cb.Content.ToString(), cb.IsChecked);
         }
+
+        private void AdvancedSearchFilter_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            var vm = this.DataContext as StashViewModel;
+
+            if (vm == null)
+                return;
+
+            var cb = sender as TextBox;
+
+            foreach (AdvancedSearchCategory category in AdvancedSearchItemControl.ItemsSource)
+            {
+                if (category.Key.ToLower().Contains(cb.Text.ToLower()))
+                {
+                    category.IsVisible = true;
+                }
+                else
+                {
+                    category.IsVisible = false;
+                }
+            }
+
+            AdvancedSearchItemControl.Items.Refresh();
+        }
     }
 }

--- a/Procurement/ViewModel/AdvancedSearchCategory.cs
+++ b/Procurement/ViewModel/AdvancedSearchCategory.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Procurement.ViewModel
+{
+    public class AdvancedSearchCategory
+    {
+        public AdvancedSearchCategory(string key, string value)
+        {
+            this.Key = key;
+            this.Value = value;
+            this.IsChecked = false;
+            this.IsVisible = true;
+        }
+
+        public string Key { get; set; }
+        public string Value { get; set; }
+        public bool IsChecked { get; set; }
+        public bool IsVisible { get; set; }
+        public System.Windows.Visibility IsVisibleString
+        {
+            get
+            {
+                return IsVisible ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed; 
+            }
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/CategoryManager.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/CategoryManager.cs
@@ -21,9 +21,15 @@ namespace Procurement.ViewModel.Filters
             initializeUserCategories();
         }
 
-        public static Dictionary<string, string> GetAvailableCategories()
+        public static List<AdvancedSearchCategory> GetAvailableCategories()
         {
-            return categories.ToDictionary(k => k.Key, k => string.Join(Environment.NewLine, k.Value.Select(filter => filter.Help)));
+            List<AdvancedSearchCategory> advancedSearchCategories = new List<AdvancedSearchCategory>();
+            foreach (var category in categories)
+            {
+                advancedSearchCategories.Add(new AdvancedSearchCategory(category.Key, string.Join(Environment.NewLine, category.Value.Select(filter => filter.Help))));
+            }
+
+            return advancedSearchCategories;
         }
 
         public static IEnumerable<IFilter> GetCategory(string category)

--- a/Procurement/ViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/StashViewModel.cs
@@ -92,7 +92,7 @@ namespace Procurement.ViewModel
 
         public ICommand GetTabs { get; set; }
 
-        public Dictionary<string, string> AvailableCategories { get; private set; }
+        public List<AdvancedSearchCategory> AvailableCategories { get; private set; }
 
         public List<string> Leagues
         {


### PR DESCRIPTION
The advanced search section is convenient, but if you're looking for specific things, it can be difficult to search through the list manually. Simply added a textbox in the "advanced search" tab where the user can type text. On KeyUp it goes through all the categories and sets the visibility attribute to "Collapsed", via a binding, if it doesn't partially match the user's input.

Filter with nothing typed: http://i.imgur.com/RsFqWSl.png
Filter with "resist" typed: http://i.imgur.com/Tk71RKU.png