### PR TITLE
Improve offline / online status handling when idle or PoE is closed.

### DIFF
--- a/Procurement/Utility/PoeTradeOnlineHelper.cs
+++ b/Procurement/Utility/PoeTradeOnlineHelper.cs
@@ -2,17 +2,34 @@
 using POEApi.Model;
 using System;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Timers;
 using System.Windows;
+using System.Linq;
 
 namespace Procurement.Utility
 {
     class PoeTradeOnlineHelper
     {
+
         private static PoeTradeOnlineHelper instance;
         private System.Timers.Timer refreshTimer;
         private Uri refreshUri;
+
+		[DllImport("user32.dll")]
+		private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
+
+		[StructLayout(LayoutKind.Sequential)]
+		private struct LASTINPUTINFO
+		{
+			public static readonly int SizeOf = Marshal.SizeOf(typeof(LASTINPUTINFO));
+			[MarshalAs(UnmanagedType.U4)]
+			public UInt32 cbSize;
+			[MarshalAs(UnmanagedType.U4)]
+			public UInt32 dwTime;
+		}
 
         private PoeTradeOnlineHelper()
         {
@@ -36,6 +53,12 @@ namespace Procurement.Utility
         {
             try
             {
+				Func<Process, bool> IsPoE = (c => c.MainWindowTitle.Contains("Path of Exile") || c.ProcessName.Contains("PathOfExile"));
+				if(GetIdleTime() >= TimeSpan.FromMinutes(10) || !Process.GetProcesses().Any(IsPoE))
+				{
+					// User is AFK or PoE is not running.
+					return;
+				}
                 using (var client = new WebClient())
                 {
                     var data = new NameValueCollection();
@@ -47,6 +70,17 @@ namespace Procurement.Utility
                 Logger.Log("Error refreshing online status in PoeTradeOnlineHelper: " + ex.ToString());
             }
         }
+
+		private TimeSpan GetIdleTime()
+		{
+			var inputInfo = new LASTINPUTINFO() {
+				cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO)),
+				dwTime = 0
+			};
+			GetLastInputInfo(ref inputInfo);
+			// Allow for TickCount wrap-around.
+			return TimeSpan.FromTicks(unchecked(Environment.TickCount - inputInfo.dwTime));
+		}
 
         internal void Start()
         {

--- a/Procurement/Utility/PoeTradeOnlineHelper.cs
+++ b/Procurement/Utility/PoeTradeOnlineHelper.cs
@@ -79,7 +79,7 @@ namespace Procurement.Utility
             };
             GetLastInputInfo(ref inputInfo);
             // Allow for TickCount wrap-around.
-            return TimeSpan.FromTicks(unchecked(Environment.TickCount - inputInfo.dwTime));
+            return TimeSpan.FromMilliseconds(unchecked(Environment.TickCount - inputInfo.dwTime));
         }
 
         internal void Start()

--- a/Procurement/Utility/PoeTradeOnlineHelper.cs
+++ b/Procurement/Utility/PoeTradeOnlineHelper.cs
@@ -18,18 +18,18 @@ namespace Procurement.Utility
         private System.Timers.Timer refreshTimer;
         private Uri refreshUri;
 
-		[DllImport("user32.dll")]
-		private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
+        [DllImport("user32.dll")]
+        private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
 
-		[StructLayout(LayoutKind.Sequential)]
-		private struct LASTINPUTINFO
-		{
-			public static readonly int SizeOf = Marshal.SizeOf(typeof(LASTINPUTINFO));
-			[MarshalAs(UnmanagedType.U4)]
-			public UInt32 cbSize;
-			[MarshalAs(UnmanagedType.U4)]
-			public UInt32 dwTime;
-		}
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LASTINPUTINFO
+        {
+            public static readonly int SizeOf = Marshal.SizeOf(typeof(LASTINPUTINFO));
+            [MarshalAs(UnmanagedType.U4)]
+            public UInt32 cbSize;
+            [MarshalAs(UnmanagedType.U4)]
+            public UInt32 dwTime;
+        }
 
         private PoeTradeOnlineHelper()
         {
@@ -53,12 +53,12 @@ namespace Procurement.Utility
         {
             try
             {
-				Func<Process, bool> IsPoE = (c => c.MainWindowTitle.Contains("Path of Exile") || c.ProcessName.Contains("PathOfExile"));
-				if(GetIdleTime() >= TimeSpan.FromMinutes(10) || !Process.GetProcesses().Any(IsPoE))
-				{
-					// User is AFK or PoE is not running.
-					return;
-				}
+                Func<Process, bool> IsPoE = (c => c.MainWindowTitle.Contains("Path of Exile") || c.ProcessName.Contains("PathOfExile"));
+                if(GetIdleTime() >= TimeSpan.FromMinutes(10) || !Process.GetProcesses().Any(IsPoE))
+                {
+                    // User is AFK or PoE is not running.
+                    return;
+                }
                 using (var client = new WebClient())
                 {
                     var data = new NameValueCollection();
@@ -71,16 +71,16 @@ namespace Procurement.Utility
             }
         }
 
-		private TimeSpan GetIdleTime()
-		{
-			var inputInfo = new LASTINPUTINFO() {
-				cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO)),
-				dwTime = 0
-			};
-			GetLastInputInfo(ref inputInfo);
-			// Allow for TickCount wrap-around.
-			return TimeSpan.FromTicks(unchecked(Environment.TickCount - inputInfo.dwTime));
-		}
+        private TimeSpan GetIdleTime()
+        {
+            var inputInfo = new LASTINPUTINFO() {
+                cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO)),
+                dwTime = 0
+            };
+            GetLastInputInfo(ref inputInfo);
+            // Allow for TickCount wrap-around.
+            return TimeSpan.FromTicks(unchecked(Environment.TickCount - inputInfo.dwTime));
+        }
 
         internal void Start()
         {


### PR DESCRIPTION
Seems to work in my testing, idle time is tracked properly and the process detection works fine for at least the international client. Since the xyz control panel is only supported on the international version, that should be sufficient.