### PR TITLE
serialize the currency ratios in a culture invariant form

### DIFF
--- a/POEApi.Model/Settings.cs
+++ b/POEApi.Model/Settings.cs
@@ -141,8 +141,8 @@ namespace POEApi.Model
             foreach (OrbType key in CurrencyRatios.Keys)
             {
                 XElement update = settingsFile.Elements("Ratios").Descendants().First(x => x.Attribute("type").Value == key.ToString());
-                update.Attribute("OrbAmount").SetValue(CurrencyRatios[key].OrbAmount.ToString());
-                update.Attribute("ChaosAmount").SetValue(CurrencyRatios[key].ChaosAmount.ToString());
+                update.Attribute("OrbAmount").SetValue(CurrencyRatios[key].OrbAmount.ToString(CultureInfo.InvariantCulture));
+                update.Attribute("ChaosAmount").SetValue(CurrencyRatios[key].ChaosAmount.ToString(CultureInfo.InvariantCulture));
             }
             
             updateLists();


### PR DESCRIPTION
, since they are deserialized in the same manner.

This is to avoid #83 

Ratios where converted to string before serialization in the current locale of the OS (hungarian in my case):

    double a = 2.5d;
    a.ToString(); // yields "2.5" if your culture settings are set to english, but yields "2,5" if they are set to hungarian.

but deserialized in invariant culture:

    var aStr = "2,5";
    double.Parse(aStr, CultureInfo.InvariantCulture); // yields 25 instead of 2.5

My solution to this is to convert doubles to string with `Cultureinfo.InvariantCulture`:

    double a = 2.5d;
    var aStr = a.ToString(CultureInfo.InvariantCulture); // yields "2.5" no matter what.
    double.Parse(aStr, CultureInfo.InvariantCulture); // yields 2.5 properly