### PR TITLE
Show crafted mods in generated images, too

### DIFF
--- a/Procurement/Controls/ItemHoverImage.xaml
+++ b/Procurement/Controls/ItemHoverImage.xaml
@@ -197,6 +197,29 @@
                                                     Converter={StaticResource VisibilityConverter},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
+                    <ItemsControl ItemsSource="{Binding CraftedMods}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding HasCraftedMods,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="#b4b4ff"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>                    
+                    
                     <TextBlock Width="{Binding Path=ActualWidth,
                                                ElementName=ItemHeader,
                                                Mode=OneWay}"


### PR DESCRIPTION
Some item properties were missing from the saved images template. I copied over crafted mods but left out MTX listing - not having the former is obviously wrong but I'm not certain about the latter.