### PR TITLE
Prevent SetBuyoutView from Closing By Click

### DIFF
--- a/Procurement/Controls/ItemDisplay.xaml.cs
+++ b/Procurement/Controls/ItemDisplay.xaml.cs
@@ -128,6 +128,7 @@ namespace Procurement.Controls
             menu.Resources = expressionDarkGrid;
 
             MenuItem setBuyout = new MenuItem();
+            setBuyout.StaysOpenOnClick = true;
 
             var buyoutControl = new SetBuyoutView();
 


### PR DESCRIPTION
Currently, when you have the SetBuyoutView open and click (left or right) anywhere in it which is *not* a control, it closes the dialog. Which unfortunately is kinda annoying and disrupts the "workflow". This oneliner prevents that.