### PR TITLE
Updating stash request URIs to work with a GGG update.

### DIFF
--- a/POEApi.Model/POEModel.cs
+++ b/POEApi.Model/POEModel.cs
@@ -85,7 +85,7 @@ namespace POEApi.Model
 
             onStashLoaded(POEEventState.BeforeEvent, index, -1);
 
-            using (Stream stream = transport.GetStash(index, league, forceRefresh))
+            using (Stream stream = transport.GetStash(index, league, Settings.ProxySettings["AccountName"], forceRefresh))
             {
                 try
                 {
@@ -123,7 +123,7 @@ namespace POEApi.Model
             throw new Exception(@"Downloading stash, details logged to DebugInfo.log, please open a ticket at https://github.com/Stickymaddness/Procurement/issues");
         }
 
-        public Stash GetStash(string league, string accountName)
+        public Stash GetStash(string league)
         {
             try
             {

--- a/POEApi.Transport/CachedTransport.cs
+++ b/POEApi.Transport/CachedTransport.cs
@@ -35,7 +35,7 @@ namespace POEApi.Transport
             return innerTranport.Authenticate(email, password, useSessionID);
         }
 
-        public Stream GetStash(int index, string league, bool refresh)
+        public Stream GetStash(int index, string league, string accountName, bool refresh)
         {
             string key = string.Format("{0}-{1}-{2}", league, stashKey, index);
 
@@ -43,14 +43,14 @@ namespace POEApi.Transport
                 userCacheService.Remove(key);
 
             if (!userCacheService.Exists(key))
-                userCacheService.Set(key, innerTranport.GetStash(index, league));
+                userCacheService.Set(key, innerTranport.GetStash(index, league, accountName));
 
             return userCacheService.Get(key);
         }
 
-        public Stream GetStash(int index, string league)
+        public Stream GetStash(int index, string league, string accountName)
         {
-            return GetStash(index, league, false);
+            return GetStash(index, league, accountName, false);
         }
 
         public Stream GetImage(string url)

--- a/POEApi.Transport/HttpTransport.cs
+++ b/POEApi.Transport/HttpTransport.cs
@@ -23,7 +23,7 @@ namespace POEApi.Transport
 
         private const string loginURL = @"https://www.pathofexile.com/login";
         private const string characterURL = @"https://www.pathofexile.com/character-window/get-characters";
-        private const string stashURL = @"https://www.pathofexile.com/character-window/get-stash-items?league={0}&tabs=1&tabIndex={1}";
+        private const string stashURL = @"https://www.pathofexile.com/character-window/get-stash-items?league={0}&tabs=1&tabIndex={1}&accountName={2}";
         private const string inventoryURL = @"http://www.pathofexile.com/character-window/get-items?character={0}&accountName={1}";
         private const string hashRegEx = "name=\\\"hash\\\" value=\\\"(?<hash>[a-zA-Z0-9]{1,})\\\"";
 
@@ -132,17 +132,17 @@ namespace POEApi.Transport
             return proxy;
         }
 
-        public Stream GetStash(int index, string league, bool refresh)
+        public Stream GetStash(int index, string league, string accountName, bool refresh)
         {
-            HttpWebRequest request = getHttpRequest(HttpMethod.GET, string.Format(stashURL, league, index));
+            HttpWebRequest request = getHttpRequest(HttpMethod.GET, string.Format(stashURL, league, index, accountName));
             HttpWebResponse response = (HttpWebResponse)request.GetResponse();
 
             return getMemoryStreamFromResponse(response);
         }
 
-        public Stream GetStash(int index, string league)
+        public Stream GetStash(int index, string league, string accountName)
         {
-            return GetStash(index, league, false);
+            return GetStash(index, league, accountName, false);
         }
 
         public Stream GetCharacters()

--- a/POEApi.Transport/ITransport.cs
+++ b/POEApi.Transport/ITransport.cs
@@ -7,8 +7,8 @@ namespace POEApi.Transport
     public interface ITransport
     {
         bool Authenticate(string email, SecureString password, bool useSessionID);
-        Stream GetStash(int index, string league);
-        Stream GetStash(int index, string league, bool refresh);
+        Stream GetStash(int index, string league, string accountName);
+        Stream GetStash(int index, string league, string accountName, bool refresh);
         Stream GetImage(string url);
         Stream GetCharacters();
         Stream GetInventory(string characterName, bool forceRefresh, string accountName);

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -271,7 +271,7 @@ namespace Procurement.ViewModel
                 return Enumerable.Empty<Item>();
 
             ApplicationState.CurrentLeague = character.League;
-            ApplicationState.Stash[character.League] = ApplicationState.Model.GetStash(character.League, AccountName);
+            ApplicationState.Stash[character.League] = ApplicationState.Model.GetStash(character.League);
             ApplicationState.Leagues.Add(character.League);
 
             return ApplicationState.Stash[character.League].Get<Item>();


### PR DESCRIPTION
Fixed an issue with stash requests failing because of a GGG update to the URI format.
It now requires account name as a key/value pair.

This should resolve everybody's problems regarding failure to download the stash on load up.
