### PR TITLE
Fix idle detection issue when a user has been logged on for a month.

### DIFF
--- a/Procurement/Utility/PoeTradeOnlineHelper.cs
+++ b/Procurement/Utility/PoeTradeOnlineHelper.cs
@@ -109,7 +109,7 @@ namespace Procurement.Utility
             };
             GetLastInputInfo(ref inputInfo);
             // Allow for TickCount wrap-around.
-            return TimeSpan.FromMilliseconds(unchecked(Environment.TickCount - inputInfo.dwTime));
+            return TimeSpan.FromMilliseconds(unchecked(Environment.TickCount - (int)inputInfo.dwTime));
         }
 
         internal void Start()


### PR DESCRIPTION
The original idle detection had a bug where it could think a user was AFK if they were logged into their computer for between (roughly) 1 and 2 months due to tick count looping around. This pull changes them to both be signed so the wraparound is consistent.