### PR TITLE
Fixed adds damage filters. Fixed +x to level of gems filters. Added t…

### DIFF
--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -152,6 +152,7 @@
     <Compile Include="ViewModel\Filters\ForumExport\AccurayFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CraftedModFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CurrencyFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\DamageChaos.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\EnchantModFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\EssenceFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\GearSearchFilters.cs" />

--- a/Procurement/ViewModel/Filters/ForumExport/DamageChaos.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageChaos.cs
@@ -1,14 +1,14 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class DamageLightning: StatFilter
+    internal class DamageChaos : StatFilter
     {
         public override FilterGroup Group
         {
             get { return FilterGroup.Damage; }
         }
 
-        public DamageLightning()
-            : base("Adds Lightning Damage", "Adds Lightning Damage", "Adds \\d+ to \\d+ Lightning Damage")
+        public DamageChaos()
+            : base("Adds Chaos Damage", "Adds Chaos Damage", "Adds \\d+ to \\d+ Chaos Damage")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/DamageCold.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageCold.cs
@@ -8,7 +8,7 @@
         }
 
         public DamageCold()
-            : base("Adds Cold Damage", "Adds Cold Damage", "Adds \\d+\\-\\d+ Cold Damage")
+            : base("Adds Cold Damage", "Adds Cold Damage", "Adds \\d+ to \\d+ Cold Damage")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/DamageFire.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageFire.cs
@@ -8,7 +8,7 @@
         }
 
         public DamageFire()
-            : base("Adds Fire Damage", "Adds Fire Damage", "Adds \\d+\\-\\d+ Fire Damage")
+            : base("Adds Fire Damage", "Adds Fire Damage", "Adds \\d+ to \\d+ Fire Damage")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/GemLevelFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/GemLevelFilter.cs
@@ -8,7 +8,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
     internal class GemLevelFilter : StatFilter
     {
         internal GemLevelFilter(string keyword)
-            : base("Increased " + keyword + " gem level", "Items that increases the level of " + keyword + " gems", "to level of " + keyword + " gems")
+            : base("Increased " + keyword + " gem level", "Items that increases the level of " + keyword + " gems", "to level of socketed " + keyword + " gems")
         { }
 
         public override FilterGroup Group
@@ -20,7 +20,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
     internal class AllGemLevelFilter : StatFilter
     {
         public AllGemLevelFilter()
-            : base("Increased all gem level", "Items that increases the level of gems", "to Level of Gems in this item")
+            : base("Increased all gem level", "Items that increases the level of gems", "to Level of Socketed Gems")
         { }
 
         public override FilterGroup Group
@@ -47,6 +47,13 @@ namespace Procurement.ViewModel.Filters.ForumExport
     {
         public LightningGemLevelFilter()
             : base("lightning")
+        { }
+    }
+
+    internal class ChaosGemLevelFilter : GemLevelFilter
+    {
+        public ChaosGemLevelFilter()
+            : base("chaos")
         { }
     }
 

--- a/Procurement/ViewModel/Filters/ForumExport/GlobalCritMultiplierFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/GlobalCritMultiplierFilter.cs
@@ -8,7 +8,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
     public class GlobalCritMultiplierFilter : ExplicitModBase
     {
         public GlobalCritMultiplierFilter()
-            : base("increased Global Critical Strike Multiplier")
+            : base("to Global Critical Strike Multiplier")
         { }
 
         public override bool CanFormCategory
@@ -23,7 +23,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public override string Help
         {
-            get { return "Items with increased Global Critical Strike Multiplier"; }
+            get { return "Items with additional Global Critical Strike Multiplier"; }
         }
 
         public override FilterGroup Group

--- a/Procurement/ViewModel/Filters/ForumExport/PhysicalDamageFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/PhysicalDamageFilter.cs
@@ -14,7 +14,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
         }
 
         public PhysicalDamageFilter()
-            : base("Adds Physical Damage", "Adds Physical Damage", "Adds \\d+\\-\\d+ Physical Damage")
+            : base("Adds Physical Damage", "Adds Physical Damage", "Adds \\d+ to \\d+ Physical Damage")
         { }
     }
 }


### PR DESCRIPTION
…hree missing chaos-related filters.

This should fix #639 and #627 

By the way, right now ExplicitModBase and StatFilter don't search in CraftedMods, so a lot of filters don't work on items with crafted mods, should it search for mods in crafted mods as well?