### PR TITLE
Fix: Session ID cookie isn't properly formatted for reading character inventory

### DIFF
--- a/POEApi.Transport/HttpTransport.cs
+++ b/POEApi.Transport/HttpTransport.cs
@@ -70,7 +70,7 @@ namespace POEApi.Transport
                     unwrappedPassword = unwrappedPassword.Trim();
                 }
 
-                credentialCookies.Add(new Cookie("POESESSID", unwrappedPassword, "/", "www.pathofexile.com"));
+                credentialCookies.Add(new Cookie("POESESSID", unwrappedPassword, "/", ".pathofexile.com"));
                 HttpWebRequest confirmAuth = getHttpRequest(HttpMethod.GET, loginURL);
                 HttpWebResponse confirmAuthResponse = (HttpWebResponse)confirmAuth.GetResponse();
 


### PR DESCRIPTION
Reverse-engineered this from cookies in Chrome; it looks like the cookie domain changed at some point, and for some bizarre reason, the character inventory endpoint (but not the stash endpoint) now relies on this specific domain.