### PR TITLE
Fix: Tab type indexing suffers from an off-by-one error …

### DIFF
--- a/Procurement/Controls/StashControl.xaml.cs
+++ b/Procurement/Controls/StashControl.xaml.cs
@@ -111,7 +111,7 @@ namespace Procurement.Controls
         {
             try
             {
-                return ApplicationState.Stash[ApplicationState.CurrentLeague].Tabs[TabNumber - 1].Type;
+                return ApplicationState.Stash[ApplicationState.CurrentLeague].Tabs[TabNumber].Type;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
. . . making quad tabs and tabs to the right of quad tabs render improperly.