### PR TITLE
A push on a key will display all the sockets

### DIFF
--- a/Procurement/Controls/ItemDisplay.xaml
+++ b/Procurement/Controls/ItemDisplay.xaml
@@ -6,6 +6,6 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid x:Name="MainGrid">
-            
+        
     </Grid>
 </UserControl>

--- a/Procurement/Controls/ItemDisplay.xaml.cs
+++ b/Procurement/Controls/ItemDisplay.xaml.cs
@@ -109,8 +109,9 @@ namespace Procurement.Controls
         private void BindSocketPopup(ItemDisplayViewModel vm)
         {
             UIElement socket = null;
+            bool isKeyPressed = false;
 
-            MainGrid.MouseEnter += (o, ev) =>
+            Action DisplaySocket = () =>
             {
                 if (socket == null)
                     socket = vm.GetSocket();
@@ -119,7 +120,36 @@ namespace Procurement.Controls
                     MainGrid.Children.Add(socket);
             };
 
-            MainGrid.MouseLeave += (o, ev) => MainGrid.Children.Remove(socket);
+            MainGrid.MouseEnter += (o, ev) =>
+            {
+                DisplaySocket();
+            };
+
+            MainGrid.MouseLeave += (o, ev) =>
+            {
+                if (!isKeyPressed)
+                    MainGrid.Children.Remove(socket);
+            };
+
+            MainWindow mainWindow = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
+            mainWindow.KeyDown += (o, ev) =>
+            { 
+                if ((ev.SystemKey == System.Windows.Input.Key.LeftAlt) ||
+                    (ev.SystemKey == System.Windows.Input.Key.RightAlt))
+                {
+                    isKeyPressed = true;
+
+                    DisplaySocket();
+                }
+            };
+
+            mainWindow.KeyUp += (o, ev) =>
+            {
+                isKeyPressed = false;
+
+                if (!MainGrid.IsMouseOver)
+                    MainGrid.Children.Remove(socket);
+            };
         }
 
         private ContextMenu getContextMenu()

--- a/Procurement/Controls/ItemDisplay.xaml.cs
+++ b/Procurement/Controls/ItemDisplay.xaml.cs
@@ -11,6 +11,7 @@ using POEApi.Model;
 using Procurement.ViewModel;
 using POEApi.Infrastructure;
 using Procurement.Utility;
+using System.Windows.Input;
 
 namespace Procurement.Controls
 {
@@ -134,8 +135,8 @@ namespace Procurement.Controls
             MainWindow mainWindow = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
             mainWindow.KeyDown += (o, ev) =>
             { 
-                if ((ev.SystemKey == System.Windows.Input.Key.LeftAlt) ||
-                    (ev.SystemKey == System.Windows.Input.Key.RightAlt))
+                if ((ev.SystemKey == Key.LeftAlt) ||
+                    (ev.SystemKey == Key.RightAlt))
                 {
                     isKeyPressed = true;
 
@@ -145,10 +146,14 @@ namespace Procurement.Controls
 
             mainWindow.KeyUp += (o, ev) =>
             {
-                isKeyPressed = false;
+                if (((Keyboard.GetKeyStates(Key.LeftAlt)  == KeyStates.None) || (Keyboard.GetKeyStates(Key.LeftAlt)  == KeyStates.Toggled)) &&
+                    ((Keyboard.GetKeyStates(Key.RightAlt) == KeyStates.None) || (Keyboard.GetKeyStates(Key.RightAlt) == KeyStates.Toggled)))
+                {
+                    isKeyPressed = false;
 
-                if (!MainGrid.IsMouseOver)
-                    MainGrid.Children.Remove(socket);
+                    if (!MainGrid.IsMouseOver)
+                        MainGrid.Children.Remove(socket);
+                }
             };
         }
 

--- a/Procurement/MainWindow.xaml.cs
+++ b/Procurement/MainWindow.xaml.cs
@@ -4,11 +4,16 @@ using Procurement.ViewModel;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Interop;
+using System;
 
 namespace Procurement
 {
     public partial class MainWindow : Window
     {
+        private static readonly int WM_SYSKEYDOWN = 0x0104;
+        private static readonly int VK_MENU = 0x12;
+
         public MainWindow()
         {
             InitializeComponent();
@@ -16,6 +21,14 @@ namespace Procurement
             ScreenController.Create(this);
             this.DataContext = ScreenController.Instance;
             this.MouseLeftButtonDown += new MouseButtonEventHandler(MainWindow_MouseLeftButtonDown);
+
+            Loaded += (o, e) =>
+            {
+                // Hook the window procedure
+                var source = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+                source.AddHook(new HwndSourceHook(WndProc));
+            };
+
             initLayout();
         }
 
@@ -47,6 +60,17 @@ namespace Procurement
         private void exit_Click(object sender, RoutedEventArgs e)
         {
             Application.Current.Shutdown();
+        }
+
+        private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            // Disables the ALT key
+            if ((msg == WM_SYSKEYDOWN) && (wParam.ToInt32() == VK_MENU))
+            {
+                handled = true;
+            }
+
+            return IntPtr.Zero;
         }
     }
 }


### PR DESCRIPTION
When an ALT key is pressed, all sockets are indicated.
When an ALT key is separated, indication goes off.

[![https://gyazo.com/4ef250b86203f82130feaa7e39a6f95e](https://i.gyazo.com/4ef250b86203f82130feaa7e39a6f95e.png)](https://gyazo.com/4ef250b86203f82130feaa7e39a6f95e)