### PR TITLE
Add new item types through 3.1

### DIFF
--- a/POEApi.Model.Tests/ItemFactoryTests.cs
+++ b/POEApi.Model.Tests/ItemFactoryTests.cs
@@ -9,13 +9,13 @@ namespace POEApi.Model.Tests
     public class ItemFactoryTests
     {
         [TestMethod]
-        public void ItemFactory_GivenItemWithAbyssalJewel_ShouldConstructItem()
+        public void ItemFactory_GivenItemWithAbyssJewel_ShouldConstructItem()
         {
-            var abyssalJewel = Build.A.JsonProxyItem
-                                      .ThatIsAnAbyssJewel();
+            var abyssJewel = Build.A.JsonProxyItem
+                                    .ThatIsAnAbyssJewel();
 
             var item = Build.A.JsonProxyItem
-                              .WithSocketedItem(abyssalJewel);
+                              .WithSocketedItem(abyssJewel);
 
             Gear result = ItemFactory.Get(item) as Gear;
 

--- a/POEApi.Model/Data.xml
+++ b/POEApi.Model/Data.xml
@@ -211,10 +211,13 @@
     <GearBaseType name="Belt">
       <Item name="Rustic Sash"/>
       <Item name="Chain Belt"/>
+      <Item name="Stygian Vise"/>
       <Item name="Leather Belt"/>
       <Item name="Heavy Belt"/>
       <Item name="Studded Belt"/>
       <Item name="Cloth Belt"/>
+      <Item name="Vanguard Belt"/>
+      <Item name="Crystal Belt"/>
     </GearBaseType>
     <GearBaseType name="Flask">
       <Item name="Small Life Flask"/>
@@ -227,6 +230,8 @@
       <Item name="Sacred Life Flask"/>
       <Item name="Hallowed Life Flask"/>
       <Item name="Sanctified Life Flask"/>
+      <Item name="Divine Life Flask"/>
+      <Item name="Eternal Life Flask"/>
 
       <Item name="Small Mana Flask"/>
       <Item name="Medium Mana Flask"/>
@@ -238,6 +243,8 @@
       <Item name="Sacred Mana Flask"/>
       <Item name="Hallowed Mana Flask"/>
       <Item name="Sanctified Mana Flask"/>
+      <Item name="Divine Mana Flask"/>
+      <Item name="Eternal Mana Flask"/>
 
       <Item name="Small Hybrid Flask"/>
       <Item name="Medium Hybrid Flask"/>
@@ -247,14 +254,21 @@
       <Item name="Hallowed Hybrid Flask"/>
 
       <Item name="Quicksilver Flask"/>
+      <Item name="Bismuth Flask"/>
+      <Item name="Stibnite Flask"/>
       <Item name="Ruby Flask"/>
       <Item name="Sapphire Flask"/>
       <Item name="Topaz Flask"/>
       <Item name="Amethyst Flask"/>
+      <Item name="Silver Flask"/>
+      <Item name="Aquamarine Flask"/>
       <Item name="Granite Flask"/>
-      <Item name="Diamond Flask"/>
       <Item name="Jade Flask"/>
       <Item name="Quartz Flask"/>
+      <Item name="Sulphur Flask"/>
+      <Item name="Basalt Flask"/>
+
+      <Item name="Diamond Flask"/>
     </GearBaseType>
     <GearBaseType name="Map">
       <Item name="Crypt Map"/>
@@ -1067,6 +1081,21 @@
       <Item name="The Eye of the Dragon"/>
       <Item name="The Blazing Fire"/>
       <Item name="Left to Fate"/>
+    </GearBaseType>
+
+    <GearBaseType name="Jewel">
+      <Item name="Cobalt Jewel"/>
+      <Item name="Crimson Jewel"/>
+      <Item name="Viridian Jewel"/>
+      <Item name="Prismatic Jewel"/>
+    </GearBaseType>
+
+    <!-- TODO: This should be named "AbyssJewel". -->
+    <GearBaseType name="AbysalJewel">
+      <Item name="Ghastly Eye Jewel"/>
+      <Item name="Hypnotic Eye Jewel"/>
+      <Item name="Murderous Eye Jewel"/>
+      <Item name="Searching Eye Jewel"/>
     </GearBaseType>
   </GearBaseTypes>
 </Data>

--- a/POEApi.Model/Data.xml
+++ b/POEApi.Model/Data.xml
@@ -1090,8 +1090,7 @@
       <Item name="Prismatic Jewel"/>
     </GearBaseType>
 
-    <!-- TODO: This should be named "AbyssJewel". -->
-    <GearBaseType name="AbysalJewel">
+    <GearBaseType name="AbyssJewel">
       <Item name="Ghastly Eye Jewel"/>
       <Item name="Hypnotic Eye Jewel"/>
       <Item name="Murderous Eye Jewel"/>

--- a/POEApi.Model/GearType/GearType.cs
+++ b/POEApi.Model/GearType/GearType.cs
@@ -26,8 +26,7 @@
         QuestItem,
         DivinationCard,
         Jewel,
-        // This should be named "AbyssJewel".
-        AbysalJewel,
+        AbyssJewel,
         Talisman,
         Breachstone,
         Leaguestone

--- a/POEApi.Model/GearType/GearType.cs
+++ b/POEApi.Model/GearType/GearType.cs
@@ -26,6 +26,7 @@
         QuestItem,
         DivinationCard,
         Jewel,
+        // This should be named "AbyssJewel".
         AbysalJewel,
         Talisman,
         Breachstone,

--- a/POEApi.Model/GearType/GearTypeFactory.cs
+++ b/POEApi.Model/GearType/GearTypeFactory.cs
@@ -28,7 +28,7 @@ namespace POEApi.Model
             { new MapRunner() },
             { new DivinationCardRunner() },
             { new JewelRunner() },
-            { new AbysalJewelRunner() },
+            { new AbyssJewelRunner() },
             { new BreachstoneRunner() },
             { new LeaguestoneRunner() },
             { new ChestRunner() } //Must always be last!

--- a/POEApi.Model/GearType/GearTypeRunner.cs
+++ b/POEApi.Model/GearType/GearTypeRunner.cs
@@ -184,11 +184,10 @@ namespace POEApi.Model
         }
     }
 
-    // TODO: This should be named AbyssJewelRunner.
-    internal class AbysalJewelRunner : GearTypeRunnerBase
+    internal class AbyssJewelRunner : GearTypeRunnerBase
     {
-        public AbysalJewelRunner()
-            : base(GearType.AbysalJewel, Settings.GearBaseTypes[GearType.AbysalJewel])
+        public AbyssJewelRunner()
+            : base(GearType.AbyssJewel, Settings.GearBaseTypes[GearType.AbyssJewel])
         {
             generalTypes.Add("Eye Jewel");
             incompatibleTypes = new List<string>() { "Jewelled Foil" };

--- a/POEApi.Model/GearType/GearTypeRunner.cs
+++ b/POEApi.Model/GearType/GearTypeRunner.cs
@@ -177,18 +177,21 @@ namespace POEApi.Model
     public class JewelRunner : GearTypeRunnerBase
     {
         public JewelRunner()
-            : base(GearType.Jewel, new List<string>())
+            : base(GearType.Jewel, Settings.GearBaseTypes[GearType.Jewel])
         {
             generalTypes.Add("Jewel");
+            incompatibleTypes = new List<string>() { "Jewelled Foil", "Eye Jewel" };
         }
     }
 
+    // TODO: This should be named AbyssJewelRunner.
     internal class AbysalJewelRunner : GearTypeRunnerBase
     {
         public AbysalJewelRunner()
-            : base(GearType.AbysalJewel, new List<string>())
+            : base(GearType.AbysalJewel, Settings.GearBaseTypes[GearType.AbysalJewel])
         {
             generalTypes.Add("Eye Jewel");
+            incompatibleTypes = new List<string>() { "Jewelled Foil" };
         }
     }
 

--- a/Procurement/ForumExportTemplate.txt
+++ b/Procurement/ForumExportTemplate.txt
@@ -17,8 +17,8 @@ Please message me here or ingame if something catches your eye. My IGN is {IGN}.
 [spoiler="          Divination Card          "]
 {DivinationCard}
 [/spoiler]
-[spoiler="          Abyssal Jewels          "]
-{AbyssalJewels}
+[spoiler="          Abyss Jewels          "]
+{AbyssJewels}
 [/spoiler]
 [spoiler="          Jewels          "]
 {NormalJewel}{MagicJewel}{RareJewel}{UniqueJewel}

--- a/Procurement/ViewModel/Filters/ForumExport/GearSearchFilters.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/GearSearchFilters.cs
@@ -160,14 +160,4 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         }
     }
-
-    class AbysallJewelFilter : GearTypeFilter
-    {
-        public AbysallJewelFilter()
-            : base(GearType.AbysalJewel, "Eye Jewels")
-        {
-
-        }
-
-    }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/ProphecyFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ProphecyFilter.cs
@@ -2,7 +2,7 @@
 
 namespace Procurement.ViewModel.Filters.ForumExport
 {
-    public class AbyssalJewelFilter : IFilter
+    public class AbyssJewelFilter : IFilter
     {
         public bool Applicable(Item item)
         {
@@ -29,7 +29,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
         {
             get
             {
-                return "Abyssal Jewel";
+                return "Abyss Jewel";
             }
         }
 
@@ -37,7 +37,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
         {
             get
             {
-                return "All Abyssal Jewels";
+                return "All Abyss Jewels";
             }
         }
 

--- a/Procurement/ViewModel/ForumExportVisitors/ProphecyVisitor.cs
+++ b/Procurement/ViewModel/ForumExportVisitors/ProphecyVisitor.cs
@@ -21,16 +21,16 @@ namespace Procurement.ViewModel.ForumExportVisitors
         }
     }
 
-    internal class AbyssalJewelVisitor : VisitorBase
+    internal class AbyssJewelVisitor : VisitorBase
     {
-        private const string TOKEN = "{AbyssalJewels}";
+        private const string TOKEN = "{AbyssJewels}";
 
         public override string Visit(IEnumerable<Item> items, string current)
         {
             if (current.IndexOf(TOKEN) < 0)
                 return current;
 
-            return current.Replace(TOKEN, runFilter<AbyssalJewelFilter>(items.OrderBy(i => i.H)));
+            return current.Replace(TOKEN, runFilter<AbyssJewelFilter>(items.OrderBy(i => i.H)));
         }
     }
 }


### PR DESCRIPTION
Various base item types have been added to the game but haven't been added to Procurement.  I've included all the ones I noticed are missing (and there will be a few more after 3.2, which I'll take a look at after it releases).  In particular, this adds Jewel and Abyss Jewel base item types to the data xml file, so items of these types have a non-null base type.

I've also fixed all the misspellings of "Abyss Jewel".  It is confusing remember which terms introduced in the Abyss League use "Abyss" versus "Abyssal".