### PR TITLE
Update same name recipe.

### DIFF
--- a/Procurement/ViewModel/Recipes/RecipeManager.cs
+++ b/Procurement/ViewModel/Recipes/RecipeManager.cs
@@ -26,8 +26,8 @@ namespace Procurement.ViewModel.Recipes
                 new GlassblowersBaubleRecipe(),
                 new CartographersChiselRecipe(),
                 new SameBaseTypeRecipe(),
-                new SameNameRecipe("Chance Orb - 2 Of The Same Name", 2, true),
                 new SameNameRecipe("Alchemy Orb - 3 Of The Same Name", 3, false),
+                new SameNameRecipe("Chance Orb - 2 Of The Same Name", 2, true),
                 //Todo: Implement Essence Combination recipe (Exclude Shrieking and "Special" essences
             };
         }

--- a/Procurement/ViewModel/Recipes/RecipeManager.cs
+++ b/Procurement/ViewModel/Recipes/RecipeManager.cs
@@ -26,8 +26,8 @@ namespace Procurement.ViewModel.Recipes
                 new GlassblowersBaubleRecipe(),
                 new CartographersChiselRecipe(),
                 new SameBaseTypeRecipe(),
-                new SameNameRecipe("Alchemy Orb - 3 Of The Same Name", 3, false),
-                new SameNameRecipe("Chance Orb - 2 Of The Same Name", 2, true),
+                new SameNameRecipe("Alchemy Orb - 3 Of The Same Name", 3),
+                new SameNameRecipe("Chance Orb - 2 Of The Same Name", 2),
                 //Todo: Implement Essence Combination recipe (Exclude Shrieking and "Special" essences
             };
         }

--- a/Procurement/ViewModel/Recipes/SameNameRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameNameRecipe.cs
@@ -10,14 +10,12 @@ namespace Procurement.ViewModel.Recipes
     {
         private string name;
         private int setCount;
-        private bool isMaxCount;
 
-        public SameNameRecipe(string recipeName, int setCount, bool isMaxCount)
+        public SameNameRecipe(string recipeName, int setCount)
             : base(66)
         {
             this.name = recipeName;
             this.setCount = setCount;
-            this.isMaxCount = isMaxCount;
         }
 
         public override string Name
@@ -63,14 +61,6 @@ namespace Procurement.ViewModel.Recipes
             }
 
             return matches;
-        }
-
-        private bool isCountMatch(int count)
-        {
-            if (isMaxCount)
-                return count == setCount;
-
-            return count >= setCount;
         }
     }
 }

--- a/Procurement/ViewModel/Recipes/SameNameRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameNameRecipe.cs
@@ -30,14 +30,18 @@ namespace Procurement.ViewModel.Recipes
 
         private IEnumerable<RecipeResult> findDuplicates(IEnumerable<POEApi.Model.Item> items, int setCount)
         {
-            var gear = items.OfType<Gear>().Where(g => g.Name != string.Empty);
-            var itemKeys = gear.GroupBy(i => i.Name).Where(g => g.Count() > 1);
+            // Gear and AbyssJewel both have Rarity, but do not inherit it from a common parent class, so we need to
+            // handle each subclass separately.
+            IEnumerable<Item> gear = items.Where(i => i.Name != string.Empty &&
+                ((i is Gear && (i as Gear).Rarity != Rarity.Unique) ||
+                 (i is AbyssJewel && (i as AbyssJewel).Rarity != Rarity.Unique)));
 
             List<RecipeResult> matches = new List<RecipeResult>();
 
+            var itemKeys = gear.GroupBy(i => i.Name).Where(g => g.Count() > 1);
             foreach (var item in itemKeys)
             {
-                var matchedItems = gear.Where(g => g.Rarity != Rarity.Unique && g.Name == item.Key)
+                var matchedItems = gear.Where(g => g.Name == item.Key)
                     .Select(g => g as Item).ToList();
 
                 while (matchedItems.Count > 0)

--- a/Procurement/ViewModel/Recipes/SameNameRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameNameRecipe.cs
@@ -13,6 +13,7 @@ namespace Procurement.ViewModel.Recipes
         private bool isMaxCount;
 
         public SameNameRecipe(string recipeName, int setCount, bool isMaxCount)
+            : base(66)
         {
             this.name = recipeName;
             this.setCount = setCount;
@@ -38,17 +39,27 @@ namespace Procurement.ViewModel.Recipes
 
             foreach (var item in itemKeys)
             {
-                var matchedItems = gear.Where(g => g.Rarity != Rarity.Unique && g.Name == item.Key).Select(g => g as Item).ToList();
+                var matchedItems = gear.Where(g => g.Rarity != Rarity.Unique && g.Name == item.Key)
+                    .Select(g => g as Item).ToList();
 
-                if (isCountMatch(matchedItems.Count()))
-                    matches.Add(new RecipeResult()
+                while (matchedItems.Count > 0)
+                {
+                    var currentSet = matchedItems.Take(setCount).ToList();
+                    matchedItems.RemoveRange(0, currentSet.Count);
+                    Decimal percentMatch = ((Decimal)currentSet.Count / setCount) * 100;
+                    var candidateMatch = new RecipeResult()
                     {
                         Instance = this,
-                        IsMatch = true,
-                        MatchedItems = matchedItems,
+                        IsMatch = percentMatch > base.ReturnMatchesGreaterThan,
+                        MatchedItems = currentSet,
                         Missing = new List<string>(),
-                        PercentMatch = 100
-                    });
+                        PercentMatch = percentMatch
+                    };
+                    if (candidateMatch.IsMatch)
+                    {
+                        matches.Add(candidateMatch);
+                    }
+                }
             }
 
             return matches;


### PR DESCRIPTION
This pull request simplifies and improves the same name recipe, and allows Abyss Jewels to be included in the results, as detailed in the commit messages.

The way the rarity of gear and abyss jewels is checked separately here is clunky, but I have some ideas I can look in to later to clean up (e.g., reorganizing some classes so they inherit Rarity from a common parent).