### PR TITLE
Include number of complete recipes in description.

### DIFF
--- a/Procurement/View/Converters/RecipeDescriptionConverter.cs
+++ b/Procurement/View/Converters/RecipeDescriptionConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Data;
 using Procurement.ViewModel.Recipes;
 
@@ -10,7 +11,8 @@ namespace Procurement.View
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             KeyValuePair<string, List<RecipeResult>> item = (KeyValuePair<string, List<RecipeResult>>)value;
-            return string.Format("{0} ({1} Results)", item.Key, item.Value.Count);
+            int numCompleteResults = item.Value.Count(i => i.PercentMatch == 100);
+            return string.Format("{0} ({1}/{2} Results)", item.Key, numCompleteResults, item.Value.Count);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)


### PR DESCRIPTION
Update the description for each section in the list of recipe results to show both the number of completed (100%) recipes, in addition to the normal number of total recipes.  This makes it easier to know at a glance if a section has any recipes that can be acted upon, instead of only knowing if there are recipes that are either close or complete.