### PR TITLE
Only process decrypted password if non-empty.

### DIFF
--- a/POEApi.Infrastructure/DPAPI.cs
+++ b/POEApi.Infrastructure/DPAPI.cs
@@ -64,10 +64,13 @@ namespace POEApi.Infrastructure
             SecureString secured = new SecureString();
 
             int count = Encoding.Unicode.GetCharCount(decrypted);
-            int bc = decrypted.Length / count;
+            if (count > 0)
+            {
+                int bc = decrypted.Length / count;
 
-            for (int i = 0; i < count; i++)
-                secured.AppendChar(Encoding.Unicode.GetChars(decrypted, i * bc, bc)[0]);
+                for (int i = 0; i < count; i++)
+                    secured.AppendChar(Encoding.Unicode.GetChars(decrypted, i * bc, bc)[0]);
+            }
 
             secured.MakeReadOnly();
 


### PR DESCRIPTION
The encrypted password has a positive length, even when the actual
password being encrypted is the empty string.  We should check that the
decrypted password is not empty so we do not divide by zero.