### PR TITLE
Sort compatible types to use longer base types.

### DIFF
--- a/POEApi.Model/GearType/GearTypeRunner.cs
+++ b/POEApi.Model/GearType/GearTypeRunner.cs
@@ -25,7 +25,7 @@ namespace POEApi.Model
             : base(gearType)
         {
             this.generalTypes = new List<string>();
-            this.compatibleTypes = compatibleTypes.ToList();
+            this.compatibleTypes = compatibleTypes.OrderByDescending(s => s.Length).ToList();
             this.incompatibleTypes = new List<string>();
         }
 

--- a/Tests/POEApi.Model.Tests/GearTests.cs
+++ b/Tests/POEApi.Model.Tests/GearTests.cs
@@ -20,5 +20,25 @@ namespace POEApi.Model.Tests
             gear.SocketedItems.Should().BeEmpty();
             gear.Sockets.Should().BeEmpty();
         }
+
+        [TestMethod]
+        public void Item_TypeLineSubstringOfOtherTypeLine_ShouldFindCorrectBaseType()
+        {
+            JSONProxy.Item tricorneProxyItem = Build.A.JsonProxyItem.WithTypeLine("Tricorne");
+            JSONProxy.Item NobleTricorneProxyItem = Build.A.JsonProxyItem.WithTypeLine("Noble Tricorne");
+            JSONProxy.Item SinnerTricorneProxyItem = Build.A.JsonProxyItem.WithTypeLine("Sinner Tricorne");
+
+            var tricorneItem = new Gear(tricorneProxyItem);
+            tricorneItem.BaseType.Should().Be("Tricorne");
+            tricorneItem.GearType.Should().Be(GearType.Helmet);
+
+            var nobleTricorneItem = new Gear(NobleTricorneProxyItem);
+            nobleTricorneItem.BaseType.Should().Be("Noble Tricorne");
+            nobleTricorneItem.GearType.Should().Be(GearType.Helmet);
+
+            var sinnerTricorneItem = new Gear(SinnerTricorneProxyItem);
+            sinnerTricorneItem.BaseType.Should().Be("Sinner Tricorne");
+            sinnerTricorneItem.GearType.Should().Be(GearType.Helmet);
+        }
     }
 }


### PR DESCRIPTION
There are base types in the same gear type where one base type is a
non-trivial substring of another base type.  For example, there are
"Tricone", "Noble Tricorne", and "Sinner Tricorne" base types.  Since we
determine and item's base type by checking if each base type is a
substring of that item's type line (since the type line can include
affixes), we need to make sure we do not use a shorter base type when a
longer one is more correct.  The simple fix used here, after building
the list of compatible types for a gear type, sort that list by string
length, so the longer strings are checked first.