### PR TITLE
Some bestiary items

### DIFF
--- a/POEApi.Model/FullBestiaryOrb.cs
+++ b/POEApi.Model/FullBestiaryOrb.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace POEApi.Model
+{
+    public class FullBestiaryOrb : Item
+    {
+        public FullBestiaryOrb(JSONProxy.Item item) : base(item)
+        {
+            this.Rarity = getRarity(item);
+            this.ItemType = ItemType.Currency;
+
+            this.Genus = ProxyMapper.GetGenus(item.Properties);
+            this.Group = ProxyMapper.GetGroup(item.Properties);
+            this.Family = ProxyMapper.GetFamily(item.Properties);
+
+            // TODO: This item's explicit mods are the mods of the contained beast.  These could be various types of
+            // mods ("prefix mod", "suffix mod", "monster mod", etc.), but only the name is provided in the JSON for
+            // the explicit mod.  Compile a list of each of these types of mods and map them here, so we can style the
+            // text of the mods correctly in the item tooltip.  Right now all of the mods have the default blue
+            // foreground text and no other styling, which is only correct for prefix/suffix mods.  Note that the
+            // in-game detailed tooltip uses "monster mod" for different kinds of mods, including bestiary beast mods
+            // (bold white text with red outline) and bloodline mods (magenta text RGB(210, 0, 220)).
+        }
+
+        public Rarity Rarity { get; }
+
+        // TODO: Compile the possible values of Genus, Group, and Family, and use enums instead of raw strings.
+        public string Genus { get; }
+        public string Group { get; }
+        public string Family { get; }
+    }
+}

--- a/POEApi.Model/ItemFactory.cs
+++ b/POEApi.Model/ItemFactory.cs
@@ -25,6 +25,10 @@ namespace POEApi.Model
                 if (item.DescrText != null && item.DescrText.ToLower() == "right click this item then left click a location on the ground to create the object.")
                     return new Decoration(item);
 
+                if (item.DescrText != null && string.Equals(item.DescrText,
+                    "Right-click to add this to your bestiary.", StringComparison.CurrentCultureIgnoreCase))
+                    return new FullBestiaryOrb(item);
+
                 if (item.TypeLine.Contains("Leaguestone"))
                     return new Leaguestone(item);
 
@@ -42,7 +46,6 @@ namespace POEApi.Model
                     if(item.TypeLine == "Offering to the Goddess")
                         return new Offering(item);
                 }
-                
 
                 return new Gear(item);
             }

--- a/POEApi.Model/ItemFactory.cs
+++ b/POEApi.Model/ItemFactory.cs
@@ -72,6 +72,9 @@ namespace POEApi.Model
             if (item.TypeLine.Contains("Sextant"))
                 return new Sextant(item);
 
+            if (item.TypeLine.Contains("Net"))
+                return new Net(item);
+
             return new Currency(item);
         }
 

--- a/POEApi.Model/Net.cs
+++ b/POEApi.Model/Net.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace POEApi.Model
+{
+    public class Net : Currency
+    {
+        public Net(JSONProxy.Item item) : base(item)
+        {
+            this.NetTier = ProxyMapper.GetNetTier(item.Properties);
+        }
+
+        public int NetTier { get; }
+    }
+}

--- a/POEApi.Model/OrbType.cs
+++ b/POEApi.Model/OrbType.cs
@@ -52,6 +52,18 @@
         BindingOrb,
         HorizonOrb,
         RegalShard,
+        BestiaryOrb,
+        SimpleRopeNet,
+        ReinforcedRopeNet,
+        StrongRopeNet,
+        SimpleIronNet,
+        ReinforcedIronNet,
+        StrongIronNet,
+        SimpleSteelNet,
+        ReinforcedSteelNet,
+        StrongSteelNet,
+        ThaumaturgicalNet,
+        NecromancyNet,
 
         //Must always be last
         Unknown

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -55,6 +55,7 @@
     <Compile Include="DivineVessel.cs" />
     <Compile Include="Essence.cs" />
     <Compile Include="EssenceType.cs" />
+    <Compile Include="FullBestiaryOrb.cs" />
     <Compile Include="GemHandler.cs" />
     <Compile Include="ItemTradeInfo.cs" />
     <Compile Include="Character.cs" />

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -77,6 +77,7 @@
     <Compile Include="JSONProxy\Stash.cs" />
     <Compile Include="Leaguestone.cs" />
     <Compile Include="Map.cs" />
+    <Compile Include="Net.cs" />
     <Compile Include="Offering.cs" />
     <Compile Include="OrbType.cs" />
     <Compile Include="Events\POEEventArgs.cs" />

--- a/POEApi.Model/ProxyMapper.cs
+++ b/POEApi.Model/ProxyMapper.cs
@@ -13,6 +13,7 @@ namespace POEApi.Model
         internal const string CHARGES = "Currently has %0 of %1 Charges";
         internal const string STASH = "Stash";
         public const string QUALITY = "Quality";
+        public const string NETTIER = "Net Tier";
         private static readonly Regex qualityRx = new Regex("[+]{1}(?<quality>[0-9]{1,2}).*");
 
         #region   Orb Types  
@@ -67,7 +68,19 @@ namespace POEApi.Model
             {"Orb of Annulment", OrbType.AnnulmentOrb},
             {"Orb of Binding", OrbType.BindingOrb},
             {"Orb of Horizons", OrbType.HorizonOrb},
-            {"Regal Shard", OrbType.RegalShard}
+            {"Regal Shard", OrbType.RegalShard},
+            {"Bestiary Orb", OrbType.BestiaryOrb},
+            {"Simple Rope Net", OrbType.SimpleRopeNet},
+            {"Reinforced Rope Net", OrbType.ReinforcedRopeNet},
+            {"Strong Rope Net", OrbType.StrongRopeNet},
+            {"Simple Iron Net", OrbType.SimpleIronNet},
+            {"Reinforced Iron Net", OrbType.ReinforcedIronNet},
+            {"Strong Iron Net", OrbType.StrongIronNet},
+            {"Simple Steel Net", OrbType.SimpleSteelNet},
+            {"Reinforced Steel Net", OrbType.ReinforcedSteelNet},
+            {"Strong Steel Net", OrbType.StrongSteelNet},
+            {"Thaumaturgical Net", OrbType.ThaumaturgicalNet},
+            {"Necromancy Net", OrbType.NecromancyNet},
         };
 
         #endregion
@@ -339,6 +352,11 @@ namespace POEApi.Model
             }
 
             return new ChargeInfo(1,1);
+        }
+
+        public static int GetNetTier(List<JSONProxy.Property> properties)
+        {
+            return Convert.ToInt32(getPropertyByName(properties, NETTIER));
         }
     }
 }

--- a/POEApi.Model/ProxyMapper.cs
+++ b/POEApi.Model/ProxyMapper.cs
@@ -14,6 +14,9 @@ namespace POEApi.Model
         internal const string STASH = "Stash";
         public const string QUALITY = "Quality";
         public const string NETTIER = "Net Tier";
+        public const string GENUS = "Genus";
+        public const string GROUP = "Group";
+        public const string FAMILY = "Family";
         private static readonly Regex qualityRx = new Regex("[+]{1}(?<quality>[0-9]{1,2}).*");
 
         #region   Orb Types  
@@ -357,6 +360,21 @@ namespace POEApi.Model
         public static int GetNetTier(List<JSONProxy.Property> properties)
         {
             return Convert.ToInt32(getPropertyByName(properties, NETTIER));
+        }
+
+        public static string GetGenus(List<JSONProxy.Property> properties)
+        {
+            return getPropertyByName(properties, GENUS);
+        }
+
+        public static string GetGroup(List<JSONProxy.Property> properties)
+        {
+            return getPropertyByName(properties, GROUP);
+        }
+
+        public static string GetFamily(List<JSONProxy.Property> properties)
+        {
+            return getPropertyByName(properties, FAMILY);
         }
     }
 }

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -169,6 +169,7 @@
     <Compile Include="ViewModel\Filters\ForumExport\DivineVesselFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\EnchantModFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\EssenceFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\FullBestiaryOrbFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\GearSearchFilters.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\GemLevelFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\IncreasedDamageFilter.cs" />
@@ -188,6 +189,7 @@
     <Compile Include="ViewModel\ForumExportVisitors\CurrencyVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\DivineVesselVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\EssenceVisitor.cs" />
+    <Compile Include="ViewModel\ForumExportVisitors\FullBestiaryOrbVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\OfferingVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\ProphecyVisitor.cs" />
     <Compile Include="ViewModel\Recipes\MatchedSet.cs" />

--- a/Procurement/ViewModel/Filters/ForumExport/FullBestiaryOrbFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/FullBestiaryOrbFilter.cs
@@ -1,0 +1,44 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class FullBestiaryOrbFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public string Keyword
+        {
+            get
+            {
+                return "Full Bestiary Orb";
+            }
+        }
+
+        public string Help
+        {
+            get
+            {
+                return "All Bestiary Orbs Containing Beasts";
+            }
+        }
+
+        public FilterGroup Group
+        {
+            get
+            {
+                return FilterGroup.Default;
+            }
+        }
+
+        public bool Applicable(Item item)
+        {
+            return item is FullBestiaryOrb;
+        }
+    }
+}

--- a/Procurement/ViewModel/ForumExportVisitors/FullBestiaryOrbVisitor.cs
+++ b/Procurement/ViewModel/ForumExportVisitors/FullBestiaryOrbVisitor.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using POEApi.Model;
+using Procurement.ViewModel.Filters.ForumExport;
+
+namespace Procurement.ViewModel.ForumExportVisitors
+{
+    // TODO: Add similar visitors that look for orbs that have exactly one or two Bestiary beast mods, once we can
+    // identify which mods those are.
+
+    internal class FullBestiaryOrbVisitor : VisitorBase
+    {
+        private const string TOKEN = "{FullBestiaryOrbs}";
+
+        public override string Visit(IEnumerable<Item> items, string current)
+        {
+            if (current.IndexOf(TOKEN) < 0)
+                return current;
+
+            return current.Replace(TOKEN, runFilter<FullBestiaryOrbFilter>(items.OrderBy(i => i.H)));
+        }
+    }
+}

--- a/Procurement/ViewModel/ItemHoverViewModelFactory.cs
+++ b/Procurement/ViewModel/ItemHoverViewModelFactory.cs
@@ -38,6 +38,12 @@ namespace Procurement.ViewModel
                 r = abyssJewel.Rarity;
             }
 
+            var fullBestiaryOrb = item as FullBestiaryOrb;
+            if (fullBestiaryOrb != null)
+            {
+                r = fullBestiaryOrb.Rarity;
+            }
+
             if (r != null)
             {
                 switch (r)


### PR DESCRIPTION
Added basic support for some Bestiary League items, including Nets, Bestiary Orbs, and filled Bestiary Orbs (those which contain a beast).  I'm not crazy about adding a separate OrbType for each kind of net, but, technically, they are currency items.  Also, as mentioned in various TODOs, there are some more complicated tasks still to do, such as determining what kinds of mods filled bestiary orbs have, and adding filters for bestiary orbs with one or two bestiary mods.