### PR TITLE
Added filters for elemental damage [with skills].

### DIFF
--- a/Procurement/ViewModel/Filters/ForumExport/IncreasedDamageFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/IncreasedDamageFilter.cs
@@ -32,4 +32,19 @@
             : base("Increased Lightning Damage", "Increased Lightning Damage", "Increased Lightning Damage")
         { }
     }
+
+    internal class IncreasedDamageFilterElemental : IncreasedDamageFilter
+    {
+        public IncreasedDamageFilterElemental()
+            : base("Increased Elemental Damage", "Increased Elemental Damage", "\\d+% increased Elemental Damage$")
+        { }
+    }
+
+    internal class IncreasedDamageFilterElementalWithAttackSkills : IncreasedDamageFilter
+    {
+        public IncreasedDamageFilterElementalWithAttackSkills()
+            : base("Increased Elemental Damage With Attack Skills", "Increased Elemental Damage With Attack Skills",
+            "\\d+% increased Elemental Damage with Attack Skills")
+        { }
+    }
 }


### PR DESCRIPTION
The first filter looks for specifically the generic bonus to all elemental damage, while the second looks for bonuses to elemental damage that apply only to attack skills.  This should address #824, aside from the caveats, below.

Caveat: like all of the stat filters, these filters do not look at Abyss Jewels.  Stat filters look at all Gear items, but Abyss Jewels are SocketableItems, which are a subclass of Item, not Gear (which is in turn a subclass of Item).  Because of this, Abyss Jewels do not keep track of their explicit mods.  Jewels are, by default, Gear items, but are not SocketableItems, which they should be, as well.  To best solve this we need a more generic way of assigning properties to different item classes.

Caveat: these filters look at both explicit and implicit mods of items.  We might want to have variations that only look at one or the other, but this (and all the other variations of mods that are possible on jewels/abyss jewels) will make the number of filters balloon to an immense and intractable amount.