### PR TITLE
Support pantheon souls

### DIFF
--- a/POEApi.Model/OrbType.cs
+++ b/POEApi.Model/OrbType.cs
@@ -64,6 +64,7 @@
         StrongSteelNet,
         ThaumaturgicalNet,
         NecromancyNet,
+        PantheonSoul,
 
         //Must always be last
         Unknown

--- a/POEApi.Model/ProxyMapper.cs
+++ b/POEApi.Model/ProxyMapper.cs
@@ -84,6 +84,7 @@ namespace POEApi.Model
             {"Strong Steel Net", OrbType.StrongSteelNet},
             {"Thaumaturgical Net", OrbType.ThaumaturgicalNet},
             {"Necromancy Net", OrbType.NecromancyNet},
+            {"Pantheon Soul", OrbType.PantheonSoul},
         };
 
         #endregion
@@ -230,6 +231,9 @@ namespace POEApi.Model
 
         private static string getPropertyByName(List<JSONProxy.Property> properties, string name)
         {
+            if (properties == null)
+                return null;
+
             var prop = properties.Find(p => p.Name == name);
 
             if (prop == null)
@@ -247,6 +251,11 @@ namespace POEApi.Model
         {
             try
             {
+                // Collapse all of the "Captured Soul of ..." into a single PantheonSoul OrbType.
+                if (name.StartsWith("Captured Soul of ", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    name = "Pantheon Soul";
+                }
                 return orbMap.First(m => name.Equals(m.Key, StringComparison.CurrentCultureIgnoreCase)).Value;
             }
             catch (Exception ex)
@@ -308,11 +317,11 @@ namespace POEApi.Model
 
         internal static StackInfo GetStackInfo(List<JSONProxy.Property> list)
         {
-            var stackSize = list.Find(p => p.Name == STACKSIZE);
-            if (stackSize == null)
+            string propertyValue = getPropertyByName(list, STACKSIZE);
+            if (string.IsNullOrWhiteSpace(propertyValue))
                 return new StackInfo(1, 1);
 
-            var stackInfo = getPropertyByName(list, STACKSIZE).Split('/');
+            var stackInfo = propertyValue.Split('/');
 
             return new StackInfo(Convert.ToInt32(stackInfo[0]), Convert.ToInt32(stackInfo[1]));
         }

--- a/POEApi.Model/ProxyMapper.cs
+++ b/POEApi.Model/ProxyMapper.cs
@@ -21,7 +21,8 @@ namespace POEApi.Model
 
         #region   Orb Types  
 
-        private static readonly Dictionary<string, OrbType> orbMap = new Dictionary<string, OrbType>
+        private static readonly Dictionary<string, OrbType> orbMap = new Dictionary<string, OrbType>(
+            StringComparer.CurrentCultureIgnoreCase)
         {
             {"Chaos Orb", OrbType.Chaos},
             {"Divine Orb", OrbType.Divine},
@@ -249,22 +250,25 @@ namespace POEApi.Model
 
         internal static OrbType GetOrbType(string name)
         {
-            try
+            if (string.IsNullOrWhiteSpace(name))
             {
-                // Collapse all of the "Captured Soul of ..." into a single PantheonSoul OrbType.
-                if (name.StartsWith("Captured Soul of ", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    name = "Pantheon Soul";
-                }
-                return orbMap.First(m => name.Equals(m.Key, StringComparison.CurrentCultureIgnoreCase)).Value;
-            }
-            catch (Exception ex)
-            {
-                Logger.Log(ex);
-                Logger.Log("ProxyMapper.GetOrbType Failed! ItemType = " + name);
-
+                Logger.Log("ProxyMapper.GetOrbType: Failed to get OrbType: name is null or white space.");
                 return OrbType.Unknown;
             }
+
+            // Collapse all of the "Captured Soul of ..." into a single PantheonSoul OrbType.
+            if (name.StartsWith("Captured Soul of ", StringComparison.CurrentCultureIgnoreCase))
+            {
+                name = "Pantheon Soul";
+            }
+
+            if (orbMap.ContainsKey(name))
+            {
+                return orbMap[name];
+            }
+
+            Logger.Log("ProxyMapper.GetOrbType: Failed to get OrbType for name '" + name + "'.");
+            return OrbType.Unknown;
         }
 
         internal static EssenceType GetEssenceType(JSONProxy.Item item)

--- a/Tests/POEApi.Model.Tests/Files.Designer.cs
+++ b/Tests/POEApi.Model.Tests/Files.Designer.cs
@@ -69,19 +69,17 @@ namespace POEApi.Model.Tests {
                 return ((byte[])(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
-        internal static byte[] SampleCharacterExpiredName
-        {
-            get
-            {
+        internal static byte[] SampleCharacterExpiredName {
+            get {
                 object obj = ResourceManager.GetObject("SampleCharacterExpiredName", resourceCulture);
                 return ((byte[])(obj));
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
@@ -98,6 +96,16 @@ namespace POEApi.Model.Tests {
         internal static byte[] SampleInventory {
             get {
                 object obj = ResourceManager.GetObject("SampleInventory", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] SampleInventoryWithPantheonSoul {
+            get {
+                object obj = ResourceManager.GetObject("SampleInventoryWithPantheonSoul", resourceCulture);
                 return ((byte[])(obj));
             }
         }

--- a/Tests/POEApi.Model.Tests/Files.resx
+++ b/Tests/POEApi.Model.Tests/Files.resx
@@ -154,4 +154,7 @@
   <data name="SampleStashWithSaintlyChainmail" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>testdata\samplestashwithsaintlychainmail.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="SampleInventoryWithPantheonSoul" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>TestData\SampleInventoryWithPantheonSoul.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
+++ b/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
@@ -121,6 +121,9 @@
       <LastGenOutput>Files.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="TestData\SampleInventoryWithPantheonSoul.json" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/Tests/POEApi.Model.Tests/PoeModelTests.cs
+++ b/Tests/POEApi.Model.Tests/PoeModelTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using FluentAssertions;
+using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -223,6 +224,34 @@ namespace POEApi.Model.Tests
                 var leagueStones = items.OfType<Leaguestone>();
                 
                 Assert.IsTrue(leagueStones.All(x => x.Charges.ToString() == "5/5"));
+            }
+        }
+
+        [TestMethod]
+        public void GetPantheonSoulInventoryTest()
+        {
+            string fakeInventoryInfo = Encoding.UTF8.GetString(Files.SampleInventoryWithPantheonSoul);
+            using (var stream = GenerateStreamFromString(fakeInventoryInfo))
+            {
+                _mockTransport.Setup(m => m.GetInventory(string.Empty, false, string.Empty)).Returns(stream);
+                var inventory = _model.GetInventory(string.Empty, false, string.Empty);
+
+                inventory.Should().NotBeNull();
+                inventory.Should().HaveCount(3);
+                Item item = inventory[2];
+
+                item.Should().NotBeNull();
+                Currency pantheonSoul = item as Currency;
+
+                pantheonSoul.Should().NotBeNull();
+                pantheonSoul.Name.Should().BeEmpty();
+                pantheonSoul.TypeLine.Should().Be("Captured Soul of The Forgotten Soldier");
+                pantheonSoul.Type.Should().Be(OrbType.PantheonSoul);
+                pantheonSoul.ItemType.Should().Be(ItemType.Currency);
+
+                pantheonSoul.StackInfo.Should().NotBeNull();
+                pantheonSoul.StackInfo.Amount.Should().Be(1);
+                pantheonSoul.StackInfo.MaxSize.Should().Be(1);
             }
         }
     }

--- a/Tests/POEApi.Model.Tests/TestData/SampleInventoryWithPantheonSoul.json
+++ b/Tests/POEApi.Model.Tests/TestData/SampleInventoryWithPantheonSoul.json
@@ -1,0 +1,88 @@
+﻿{
+  "items": [
+    {
+      "verified": false,
+      "w": 1,
+      "h": 1,
+      "ilvl": 59,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Rings/TopazRuby.png?scale=1&scaleIndex=0&w=1&h=1&v=0bd3c7197b952981eb21cb0dc278c04d",
+      "league": "SSF Bestiary",
+      "id": "900504aca8b996685fe0e2dd5b4daa624dd072358bb4025f42c5a195fb0c891f",
+      "name": "<<set:MS>><<set:M>><<set:S>>Soul Band",
+      "typeLine": "Two-Stone Ring",
+      "identified": true,
+      "requirements": [
+        {
+          "name": "Level",
+          "values": [ [ "35", 0 ] ],
+          "displayMode": 0
+        }
+      ],
+      "implicitMods": [ "+14% to Fire and Lightning Resistances" ],
+      "explicitMods": [ "+28 to Intelligence", "+159 to Accuracy Rating", "8% increased Accuracy Rating", "+47 to maximum Mana", "15% increased Light Radius" ],
+      "craftedMods": [ "Adds 4 to 36 Lightning Damage to Attacks" ],
+      "frameType": 2,
+      "category": { "accessories": [ "ring" ] },
+      "x": 0,
+      "y": 0,
+      "inventoryId": "Ring2"
+    },
+    {
+      "verified": false,
+      "w": 1,
+      "h": 1,
+      "ilvl": 0,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyUpgradeToMagic.png?scale=1&scaleIndex=0&stackSize=10&w=1&h=1&v=333b8b5e28b73c62972fc66e7634c5c8",
+      "league": "SSF Bestiary",
+      "id": "2de199a7b3b44e6b85988398d2839b1d6e8e8a8970637f03665c7209b378fe3a",
+      "name": "",
+      "typeLine": "Orb of Transmutation",
+      "identified": true,
+      "properties": [
+        {
+          "name": "Stack Size",
+          "values": [ [ "10/40", 0 ] ],
+          "displayMode": 0
+        }
+      ],
+      "explicitMods": [ "Upgrades a normal item to a magic item" ],
+      "descrText": "Right click this item then left click a normal item to apply it.",
+      "frameType": 5,
+      "stackSize": 10,
+      "maxStackSize": 40,
+      "category": { "currency": [] },
+      "x": 7,
+      "y": 4,
+      "inventoryId": "MainInventory"
+    },
+    {
+      "verified": false,
+      "w": 1,
+      "h": 2,
+      "ilvl": 0,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Maps/SinFlaskFull.png?scale=1&scaleIndex=0&w=1&h=2&v=5b5013c16e62ef679c9b044358ff87cf",
+      "league": "SSF Bestiary",
+      "id": "324fd79cea5be0b3d3a521251edd6417fb470bb8262d4af865298d84a6429674",
+      "name": "",
+      "typeLine": "Captured Soul of The Forgotten Soldier",
+      "identified": true,
+      "lockedToCharacter": true,
+      "descrText": "A captured Soul. Give to Sin to unlock a secondary Pantheon Power.",
+      "flavourText": [ "Though his mind decayed with each passing wave,\r", "the Brine King stood steadfast in his hatred,\r", "and wore it like a shell, protecting himself \r", "from his failure to sire a worthy heir." ],
+      "frameType": 5,
+      "category": { "currency": [ "soul" ] },
+      "x": 0,
+      "y": 3,
+      "inventoryId": "MainInventory"
+    }
+  ],
+  "character": {
+    "name": "Tsuesaki",
+    "league": "SSF Bestiary",
+    "classId": 3,
+    "ascendancyClass": 2,
+    "class": "Elementalist",
+    "level": 76,
+    "experience": 631062590
+  }
+}


### PR DESCRIPTION
The key point here is to more gracefully search an item's properties, so there are no exceptions thrown if an item's properties are null.  With this, we can properly identify and initialize Pantheon Soul items.  This PR also adds an OrbType of PantheonSoul, and all Pantheon Soul items will use this type (instead of having a separate OrbType for each kind of captured soul, which is completely unnecessary.  They're can't even be traded.

This PR should fix #826, and provides an example BIN file with a PantheonSoul for further investigation of #833.