### PR TITLE
Handle necromancy nets

### DIFF
--- a/POEApi.Model/ItemFactory.cs
+++ b/POEApi.Model/ItemFactory.cs
@@ -55,7 +55,23 @@ namespace POEApi.Model
                 var errorMessage = "ItemFactory unable to instantiate type : " + item.TypeLine;
                 Logger.Log(errorMessage);
 
-                return new UnknownItem();
+                try
+                {
+                    // Try to fall back and create an unknownItem based off of the provided item object.  This will
+                    // hopefully preserve enough properties so Procurement does not crash elsewhere and the issue is
+                    // more easily debuggable.
+                    var baseItemShell = new UnknownItem(item, ex.ToString());
+                    Logger.Log("Successfully instantiated base item shell for item.");
+                    return baseItemShell;
+                }
+                catch (Exception innerException)
+                {
+                    Logger.Log(innerException);
+                    errorMessage = "Additionally, failed to instantiate base item shell for type : " + item.TypeLine;
+                    Logger.Log(errorMessage);
+
+                    return new UnknownItem();
+                }
             }
         }
 

--- a/POEApi.Model/Net.cs
+++ b/POEApi.Model/Net.cs
@@ -12,6 +12,7 @@ namespace POEApi.Model
             this.NetTier = ProxyMapper.GetNetTier(item.Properties);
         }
 
+        // Note: Necromancy nets technically do not have a net tier, but uses the default value of 0 here.
         public int NetTier { get; }
     }
 }

--- a/POEApi.Model/ProxyMapper.cs
+++ b/POEApi.Model/ProxyMapper.cs
@@ -372,7 +372,11 @@ namespace POEApi.Model
 
         public static int GetNetTier(List<JSONProxy.Property> properties)
         {
-            return Convert.ToInt32(getPropertyByName(properties, NETTIER));
+            string maybeNetTier = getPropertyByName(properties, NETTIER);
+            if (string.IsNullOrWhiteSpace(maybeNetTier))
+                return 0;
+
+            return Convert.ToInt32(maybeNetTier);
         }
 
         public static string GetGenus(List<JSONProxy.Property> properties)

--- a/POEApi.Model/UnknownItem.cs
+++ b/POEApi.Model/UnknownItem.cs
@@ -6,5 +6,17 @@
 
         public UnknownItem() : base(getDefaultItem())
         { }
+
+        public UnknownItem(JSONProxy.Item item) : base(item)
+        { }
+
+        public UnknownItem(JSONProxy.Item item, string errorInformation) : this(item)
+        {
+            ItemSource = item;
+            ErrorInformation = errorInformation;
+        }
+
+        public JSONProxy.Item ItemSource { get; }
+        public string ErrorInformation { get; }
     }
 }

--- a/Tests/POEApi.Model.Tests/Files.Designer.cs
+++ b/Tests/POEApi.Model.Tests/Files.Designer.cs
@@ -163,6 +163,16 @@ namespace POEApi.Model.Tests {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
+        internal static byte[] SampleStashWithNets {
+            get {
+                object obj = ResourceManager.GetObject("SampleStashWithNets", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
         internal static byte[] SampleStashWithRelic {
             get {
                 object obj = ResourceManager.GetObject("SampleStashWithRelic", resourceCulture);

--- a/Tests/POEApi.Model.Tests/Files.resx
+++ b/Tests/POEApi.Model.Tests/Files.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -156,5 +156,8 @@
   </data>
   <data name="SampleInventoryWithPantheonSoul" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>TestData\SampleInventoryWithPantheonSoul.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="SampleStashWithNets" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>TestData\SampleStashWithNets.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
+++ b/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
@@ -92,6 +92,7 @@
     <None Include="TestData\SampleStashWithDivineVessel.json" />
     <None Include="TestData\SampleStashWithEssences.json" />
     <None Include="TestData\SampleStashWithLitheBlade.json" />
+    <None Include="TestData\SampleStashWithNets.json" />
     <None Include="TestData\SampleStashWithRelic.json" />
     <None Include="TestData\SampleStashWithRemnantOfCorruption.json" />
     <None Include="TestData\SampleStashWithLeagueStoneChargeInfo.json" />

--- a/Tests/POEApi.Model.Tests/PoeModelTests.cs
+++ b/Tests/POEApi.Model.Tests/PoeModelTests.cs
@@ -254,5 +254,43 @@ namespace POEApi.Model.Tests
                 pantheonSoul.StackInfo.MaxSize.Should().Be(1);
             }
         }
+
+        [TestMethod]
+        public void GetNetsStashTest()
+        {
+            string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithNets);
+            using (var stream = GenerateStreamFromString(fakeStashInfo))
+            {
+                _mockTransport.Setup(m => m.GetStash(0, string.Empty, string.Empty, false)).Returns(stream);
+
+                var stash = _model.GetStash(0, string.Empty, string.Empty);
+                stash.Should().NotBeNull();
+                stash.Tabs.Should().HaveCount(1);
+
+                var items = stash.GetItemsByTab(5);
+                items.Should().NotBeNull();
+                items.Should().HaveCount(5);
+
+                items.Should().AllBeAssignableTo<Currency>();
+
+                var simpleRopeNet = items[1] as Net;
+                simpleRopeNet.Should().NotBeNull();
+                simpleRopeNet.Name.Should().BeEmpty();
+                simpleRopeNet.TypeLine.Should().Be("Simple Rope Net");
+                simpleRopeNet.NetTier.Should().Be(1);
+
+                var thaumaturgicalNet = items[3] as Net;
+                thaumaturgicalNet.Should().NotBeNull();
+                thaumaturgicalNet.Name.Should().BeEmpty();
+                thaumaturgicalNet.TypeLine.Should().Be("Thaumaturgical Net");
+                thaumaturgicalNet.NetTier.Should().Be(10);
+
+                var necromancyNet = items[4] as Net;
+                necromancyNet.Should().NotBeNull();
+                necromancyNet.Name.Should().BeEmpty();
+                necromancyNet.TypeLine.Should().Be("Necromancy Net");
+                necromancyNet.NetTier.Should().Be(0);
+            }
+        }
     }
 }

--- a/Tests/POEApi.Model.Tests/TestData/SampleStashWithNets.json
+++ b/Tests/POEApi.Model.Tests/TestData/SampleStashWithNets.json
@@ -1,0 +1,237 @@
+﻿{
+  "numTabs": 1,
+  "tabs": [
+    {
+      "n": "$$$",
+      "i": 5,
+      "id": "003864bc2a05733e0511ec9a10baaab91d05431a924192b4d47362f51e8c35ed",
+      "type": "PremiumStash",
+      "hidden": false,
+      "selected": true,
+      "colour": {
+        "r": 191,
+        "g": 94,
+        "b": 0
+      },
+      "srcL": "https://web.poecdn.com/gen/image/WzI0LCIwMmExOTc3ZDFkMDM0NDM2ZTc3MzlmODNkMTNiMjA3ZiIsWzIseyJ0IjoxLCJuIjoiIiwiYyI6LTQyMzU3NzZ9XV0,/2c8b976348/Stash_TabL.png",
+      "srcC": "https://web.poecdn.com/gen/image/WzI0LCIwMmExOTc3ZDFkMDM0NDM2ZTc3MzlmODNkMTNiMjA3ZiIsWzIseyJ0IjoyLCJuIjoiIiwiYyI6LTQyMzU3NzZ9XV0,/0e65837146/Stash_TabC.png",
+      "srcR": "https://web.poecdn.com/gen/image/WzI0LCIwMmExOTc3ZDFkMDM0NDM2ZTc3MzlmODNkMTNiMjA3ZiIsWzIseyJ0IjozLCJuIjoiIiwiYyI6LTQyMzU3NzZ9XV0,/3c4393c68a/Stash_TabR.png"
+    }
+  ],
+  "items": [
+    {
+      "verified": false,
+      "w": 1,
+      "h": 1,
+      "ilvl": 0,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Currency/CurrencyArmourQuality.png?scale=1&scaleIndex=3&stackSize=395&w=1&h=1&v=251e204e4ec325f75ce8ef75b2dfbeb8",
+      "league": "SSF Bestiary",
+      "id": "48a34a13c25922a5130bd96d5365a4bc9e583bb379e4edba0ec3b4ff7014f171",
+      "name": "",
+      "typeLine": "Armourer's Scrap",
+      "identified": true,
+      "properties": [
+        {
+          "name": "Stack Size",
+          "values": [
+            [
+              "395/40",
+              0
+            ]
+          ],
+          "displayMode": 0
+        }
+      ],
+      "explicitMods": [
+        "Improves the quality of an armour"
+      ],
+      "descrText": "Right click this item then left click an armour to apply it. Has greater effect on lower rarity armours. The maximum quality is 20%.",
+      "frameType": 5,
+      "stackSize": 395,
+      "maxStackSize": 5000,
+      "category": {
+        "currency": [
+
+        ]
+      },
+      "x": 3,
+      "y": 0,
+      "inventoryId": "Stash6"
+    },
+    {
+      "verified": false,
+      "w": 1,
+      "h": 1,
+      "ilvl": 0,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Currency/BestiaryTrap1.png?scale=1&scaleIndex=3&stackSize=5&w=1&h=1&v=f9b8f3d1b2d33910cfa64f67276957b1",
+      "league": "SSF Bestiary",
+      "id": "1949cdab8ea9bba642c707ad5a7756f672758fc1c41ea12b44da6b9effce3a97",
+      "name": "",
+      "typeLine": "Simple Rope Net",
+      "identified": true,
+      "properties": [
+        {
+          "name": "Stack Size",
+          "values": [
+            [
+              "5/100",
+              0
+            ]
+          ],
+          "displayMode": 0
+        },
+        {
+          "name": "Net Tier",
+          "values": [
+            [
+              "1",
+              0
+            ]
+          ],
+          "displayMode": 0,
+          "type": 19
+        }
+      ],
+      "explicitMods": [
+        "Effective against Beasts of levels 1 to 13.\r\nActivate to use this type of Net when capturing Beasts."
+      ],
+      "frameType": 5,
+      "stackSize": 5,
+      "maxStackSize": 5000,
+      "category": {
+        "currency": [
+
+        ]
+      },
+      "x": 48,
+      "y": 0,
+      "inventoryId": "Stash6"
+    },
+    {
+      "verified": false,
+      "w": 1,
+      "h": 1,
+      "ilvl": 0,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Currency/BestiaryOrbEmpty.png?scale=1&scaleIndex=3&stackSize=1&w=1&h=1&v=1e94ab199c10ad04197871406542f16e",
+      "league": "SSF Bestiary",
+      "id": "266784bb0259a6e44f09032332f61062ab50545c1b9e382c7995dcf82b8e9ea0",
+      "name": "",
+      "typeLine": "Bestiary Orb",
+      "identified": true,
+      "properties": [
+        {
+          "name": "Stack Size",
+          "values": [
+            [
+              "1/10",
+              0
+            ]
+          ],
+          "displayMode": 0
+        }
+      ],
+      "explicitMods": [
+        "Stores a Beast in an item so it can be traded"
+      ],
+      "descrText": "Right click on this item then left click on a Beast in your Menagerie to turn it into a tradable item.",
+      "frameType": 5,
+      "stackSize": 1,
+      "maxStackSize": 5000,
+      "category": {
+        "currency": [
+
+        ]
+      },
+      "x": 32,
+      "y": 0,
+      "inventoryId": "Stash6"
+    },
+    {
+      "verified": false,
+      "w": 1,
+      "h": 1,
+      "ilvl": 0,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Currency/BestiaryTrap10.png?scale=1&scaleIndex=3&stackSize=9&w=1&h=1&v=44f385e2b49f1e40b1ba21ece93f8197",
+      "league": "SSF Bestiary",
+      "id": "7b865b6584c2acdee156f557c7ec62a315318dd1de64795e541e224563e8723c",
+      "name": "",
+      "typeLine": "Thaumaturgical Net",
+      "identified": true,
+      "properties": [
+        {
+          "name": "Stack Size",
+          "values": [
+            [
+              "9/100",
+              0
+            ]
+          ],
+          "displayMode": 0
+        },
+        {
+          "name": "Net Tier",
+          "values": [
+            [
+              "10",
+              0
+            ]
+          ],
+          "displayMode": 0,
+          "type": 19
+        }
+      ],
+      "explicitMods": [
+        "Effective against Beasts of levels 68 and above.\r\nActivate to use this type of Net when capturing Beasts."
+      ],
+      "frameType": 5,
+      "stackSize": 9,
+      "maxStackSize": 5000,
+      "category": {
+        "currency": [
+
+        ]
+      },
+      "x": 34,
+      "y": 0,
+      "inventoryId": "Stash6"
+    },
+    {
+      "verified": false,
+      "w": 1,
+      "h": 1,
+      "ilvl": 0,
+      "icon": "https://web.poecdn.com/image/Art/2DItems/Currency/Necronet.png?scale=1&scaleIndex=3&stackSize=1&w=1&h=1&v=f335b00f477fa75f8c803c8eebaee6c2",
+      "league": "SSF Bestiary",
+      "id": "e4b9bb2dfb5df5e5671425e766afe22d494881878de6b6ae7dc80c4322605162",
+      "name": "",
+      "typeLine": "Necromancy Net",
+      "identified": true,
+      "properties": [
+        {
+          "name": "Stack Size",
+          "values": [
+            [
+              "1/100",
+              0
+            ]
+          ],
+          "displayMode": 0
+        }
+      ],
+      "explicitMods": [
+        "Can be used on Beast corpses of all levels.\r\nActivate to use this type of Net when capturing Beasts."
+      ],
+      "frameType": 5,
+      "stackSize": 1,
+      "maxStackSize": 5000,
+      "category": {
+        "currency": [
+
+        ]
+      },
+      "x": 33,
+      "y": 0,
+      "inventoryId": "Stash6"
+    }
+  ]
+}


### PR DESCRIPTION
Necromancy Nets do not have a net tier, so right now Procurement fails to create a `Net` item for Necromancy Nets.  It does successfully create an `UnknownItem`, but, since this item type has basically no properties set, this "fake" item does not show up in the tab/inventory UI (since `InventoryId` is null) and can cause exceptions or crashes elsewhere (e.g., in the various item visitors which assume the `TypeLine` is not null).

So, first, this PR properly creates Necromancy Nets, as it does not balk at a missing `NetTier` property.  And, second, when items do fail to be created, try to populate the resulting `UnknownItem` with more information (by passing the underlying `JSONProxy.Item` object to the parent `Item` constructor), which will allow that item to show up in the UI and prevent other errors.

Note: I expect this PR will have merge conflicts with #834.  I'll rebase one onto the other after one is merged.

This PR fixes #832.