### PR TITLE
Added visitor and filter for UnknownItem.

### DIFF
--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -186,12 +186,14 @@
     <Compile Include="ViewModel\Filters\ForumExport\SixLink.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\SixRedSockets.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\SocketColourFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\UnknownItemFilter.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\CurrencyVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\DivineVesselVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\EssenceVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\FullBestiaryOrbVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\OfferingVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\ProphecyVisitor.cs" />
+    <Compile Include="ViewModel\ForumExportVisitors\UnknownItemVisitor.cs" />
     <Compile Include="ViewModel\Recipes\MatchedSet.cs" />
     <Compile Include="ViewModel\SetTabBuyoutViewModel.cs" />
     <Compile Include="ViewModel\TradeSettingsViewModel.cs" />

--- a/Procurement/ViewModel/Filters/ForumExport/UnknownItemFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/UnknownItemFilter.cs
@@ -1,0 +1,44 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class UnknownItemFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public string Keyword
+        {
+            get
+            {
+                return "Unknown Item";
+            }
+        }
+
+        public string Help
+        {
+            get
+            {
+                return "All Items Procurement Cannot Identify";
+            }
+        }
+
+        public FilterGroup Group
+        {
+            get
+            {
+                return FilterGroup.Default;
+            }
+        }
+
+        public bool Applicable(Item item)
+        {
+            return item is UnknownItem;
+        }
+    }
+}

--- a/Procurement/ViewModel/ForumExportVisitors/UnknownItemVisitor.cs
+++ b/Procurement/ViewModel/ForumExportVisitors/UnknownItemVisitor.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using POEApi.Model;
+using Procurement.ViewModel.Filters.ForumExport;
+
+namespace Procurement.ViewModel.ForumExportVisitors
+{
+    internal class UnknownItemVisitor : VisitorBase
+    {
+        private const string TOKEN = "{UnknownItems}";
+
+        public override string Visit(IEnumerable<Item> items, string current)
+        {
+            if (current.IndexOf(TOKEN) < 0)
+                return current;
+
+            return current.Replace(TOKEN, runFilter<UnknownItemFilter>(items.OrderBy(i => i.H)));
+        }
+    }
+}


### PR DESCRIPTION
This is mostly as a debugging tool.  If any items show up in this filter, then there's an outstanding bug with Procurement that needs to be fixed.

Note that, without 2c3d7f4 in #835, `UnknownItem` objects will always have a null `InventoryId`, and therefore never show up in the stash/inventory UI, and will not be found by this filter.  Compared to master, with only this PR and #835 merged, this filter will show items such as Pantheon Souls (but not after #834 is merged).