### PR TITLE
Revise flavour text and ItemHover handling

### DIFF
--- a/POEApi.Model/Gear.cs
+++ b/POEApi.Model/Gear.cs
@@ -6,7 +6,6 @@ namespace POEApi.Model
     public class Gear : Item
     {
         public Rarity Rarity { get; private set; }
-        public List<string> FlavourText { get; set; }
         public List<Socket> Sockets { get; set; }
         public List<SocketableItem> SocketedItems { get; set; }
         public List<string> Implicitmods { get; set; }
@@ -17,7 +16,6 @@ namespace POEApi.Model
         public Gear(JSONProxy.Item item) : base(item)
         {
             this.Rarity = getRarity(item);
-            this.FlavourText = item.FlavourText;
             this.Sockets = getSockets(item);
             this.Explicitmods = item.ExplicitMods;
             this.SocketedItems = getSocketedItems(item);

--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -46,6 +46,7 @@ namespace POEApi.Model
         public bool Corrupted { get; private set; }
         public List<string> Microtransactions { get; set; }
         public List<String> EnchantMods { get; set; }
+        public List<string> FlavourText { get; set; }
 
         public List<string> CraftedMods { get; set; }
 
@@ -77,6 +78,7 @@ namespace POEApi.Model
             this.ItemType = Model.ItemType.UnSet;
             this.CraftedMods = item.CraftedMods;
             this.EnchantMods = item.EnchantMods;
+            this.FlavourText = item.FlavourText;
             this.ItemLevel = item.Ilvl;
             this.Shaper = item.Shaper;
             this.Elder = item.Elder;

--- a/POEApi.Model/Prophecy.cs
+++ b/POEApi.Model/Prophecy.cs
@@ -5,13 +5,11 @@ namespace POEApi.Model
     public class Prophecy : Item
     {
         public string ProphecyText { get; set; }
-        public List<string> FlavourText { get; set; }
         public string ProphecyDifficultyText { get; set; }
 
         internal Prophecy(JSONProxy.Item item) : base(item)
         {
             this.ProphecyText = item.ProphecyText;
-            this.FlavourText = item.FlavourText;
             this.ProphecyDifficultyText = item.ProphecyDiffText;
         }
     }

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -68,6 +68,18 @@
                 </Border.Background>
                 <StackPanel>
 
+                    <!--
+                      KNOWN ISSUES:
+                        - Different dividers between different parts of text are not styled differently.  Instead, the
+                          type of item determines what color the dividers will be.  Examples include: gems,
+                          phrophecies, and normal/magic/rare/unique items.
+                        - Items without DescriptionText will have an extra divider at the bottom of the ItemHover
+                          window.  I'm not sure of a good way to exclude it without complicated converters and/or lots
+                          of cascading if/else blocks.  But it looks like dividers are placed correctly between
+                          sections in all cases and all sections are being displayed.
+                        - Some sections, under some conditions, have extra space before or between lines.
+                    -->
+
                     <TextBlock Width="{Binding Path=ActualWidth,
                                                ElementName=ItemHeader,
                                                Mode=OneWay}"
@@ -80,8 +92,16 @@
                                TextWrapping="Wrap"
                                Visibility="{Binding IsGear,
                                Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />                    
-                    
+                               ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding IsGear,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
                     <ItemsControl ItemsSource="{Binding Properties}" Padding="0 5 0 5">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
@@ -91,7 +111,11 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel>
-                                    <v:BindableRichTextBox Width="{Binding Path=ActualWidth, ElementName=ItemHeader, Mode=OneWay}" Document="{Binding Converter={StaticResource pc}}" />
+                                    <v:BindableRichTextBox
+                                        Width="{Binding Path=ActualWidth,
+                                                ElementName=ItemHeader,
+                                                Mode=OneWay}"
+                                        Document="{Binding Converter={StaticResource pc}}" />
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -101,7 +125,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasRequirements,
+                            Visibility="{Binding Properties,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -117,7 +141,7 @@
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
-                            Visibility="{Binding SecondaryDescriptionText,
+                            Visibility="{Binding HasRequirements,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -139,7 +163,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasEnchantMods,
+                            Visibility="{Binding SecondaryDescriptionText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
                     
@@ -170,7 +194,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasImplicitMods,
+                            Visibility="{Binding HasEnchantMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -200,7 +224,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasExplicitMods,
+                            Visibility="{Binding HasImplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -254,7 +278,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasMicrotransactions,
+                            Visibility="{Binding HasExplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -284,7 +308,95 @@
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
-                            Visibility="{Binding DescriptionText,
+                            Opacity="0.7"
+                            Visibility="{Binding HasMicrotransactions,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                               HorizontalAlignment="Center"
+                               FontFamily="../Resources/#Fontin SmallCaps"
+                               FontStyle="Italic"
+                               Foreground="#9E6025"
+                               Padding="10 0 10 5"
+                               Text="{Binding FlavourText}"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap"
+                               Visibility="{Binding FlavourText,
+                               Converter={StaticResource bc},
+                               ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding FlavourText,
+                                                 Converter={StaticResource VisibilityConverter},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                               HorizontalAlignment="Center"
+                               FontFamily="../Resources/#Fontin SmallCaps"
+                               Foreground="White"
+                               Padding="10 0 10 5"
+                               Text="{Binding ProphecyText}"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap"
+                               Visibility="{Binding ProphecyText,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding ProphecyText,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                               HorizontalAlignment="Center"
+                               FontFamily="../Resources/#Fontin SmallCaps"
+                               Foreground="#FF808080"
+                               Padding="10 0 10 5"
+                               Text="{Binding ProphecyDifficultyText}"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap"
+                               Visibility="{Binding ProphecyDifficultyText,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding ProphecyDifficultyText,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                               HorizontalAlignment="Center"
+                               FontFamily="../Resources/#Fontin SmallCaps"
+                               Foreground="#960003"
+                               Padding="10 0 10 5"
+                               Text="Corrupted"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap"
+                               Visibility="{Binding IsCorrupted,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding IsCorrupted,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -301,100 +413,6 @@
                                Visibility="{Binding DescriptionText,
                                                     Converter={StaticResource VisibilityConverter},
                                                     ConverterParameter=CollapseWhenFalse}" />
-
-
-
-
-                    <ItemsControl ItemsSource="{Binding ProphecyFlavour}"
-                                  Padding="10 0 10 5"
-                                  Visibility="{Binding IsProphecy,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel Orientation="Vertical" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel>
-                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
-                                               Foreground="#9E6025"
-                                               Text="{Binding}"
-                                               TextAlignment="Center"
-                                               TextWrapping="Wrap" />
-                                </StackPanel>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
-                            BorderThickness="1"
-                            Opacity="0.7"
-                            Visibility="{Binding IsProphecy,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />                    
-                    
-
-                    <TextBlock Width="{Binding Path=ActualWidth,
-                                               ElementName=ItemHeader,
-                                               Mode=OneWay}"
-                               HorizontalAlignment="Center"
-                               FontFamily="../Resources/#Fontin SmallCaps"
-                               Foreground="White"
-                               Padding="10 0 10 5"
-                               Text="{Binding ProphecyText}"
-                               TextAlignment="Center"
-                               TextWrapping="Wrap"
-                               Visibility="{Binding IsProphecy,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />
-
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
-                            BorderThickness="1"
-                            Opacity="0.7"
-                            Visibility="{Binding IsProphecy,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />
-
-                    <TextBlock Width="{Binding Path=ActualWidth,
-                                               ElementName=ItemHeader,
-                                               Mode=OneWay}"
-                               HorizontalAlignment="Center"
-                               FontFamily="../Resources/#Fontin SmallCaps"
-                               Foreground="#FF808080"
-                               Padding="10 0 10 5"
-                               Text="{Binding ProphecyDifficultyText}"
-                               TextAlignment="Center"
-                               TextWrapping="Wrap"
-                               Visibility="{Binding IsProphecy,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />
-
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
-                            BorderThickness="1"
-                            Opacity="0.7"
-                            Visibility="{Binding IsProphecy,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />
-
-                    <TextBlock Width="{Binding Path=ActualWidth,
-                                               ElementName=ItemHeader,
-                                               Mode=OneWay}"
-                               HorizontalAlignment="Center"
-                               FontFamily="../Resources/#Fontin SmallCaps"
-                               Foreground="#960003"
-                               Padding="10 0 10 5"
-                               Text="Corrupted"
-                               TextAlignment="Center"
-                               TextWrapping="Wrap"
-                               Visibility="{Binding IsCorrupted,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />
-
                 </StackPanel>
             </Border>
         </DockPanel>

--- a/Procurement/View/VisibilityConverter.cs
+++ b/Procurement/View/VisibilityConverter.cs
@@ -30,7 +30,7 @@ namespace Procurement.View
 
                     if (enumerable != null)
                     {
-                        result = enumerable.Cast<object>().Any() ? Visibility.Hidden : Visibility.Visible;
+                        result = enumerable.Cast<object>().Any() ? Visibility.Visible : Visibility.Hidden;
                     }
                     else  if (value is int)
                     {

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -37,7 +37,6 @@ namespace Procurement.ViewModel
         public bool IsProphecy { get; set; }
         public string ProphecyText { get; set; }
         public string ProphecyDifficultyText { get; set; }
-        public List<string> ProphecyFlavour { get; set; }
         public bool IsGear { get; set; }
 
         public string ItemLevel { get; set; }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -29,6 +29,7 @@ namespace Procurement.ViewModel
         public bool HasMicrotransactions { get; private set; }
         public List<string> EnchantMods { get; private set; }
         public bool HasEnchantMods { get; private set; }
+        public string FlavourText { get; private set; }
 
         public List<string> CraftedMods { get; set; }
 
@@ -75,6 +76,11 @@ namespace Procurement.ViewModel
             this.HasEnchantMods = item.EnchantMods.Count > 0;
             this.HasRequirements = Requirements != null && Requirements.Count > 0;
 
+            if (item.FlavourText?.Count > 0)
+            {
+                this.FlavourText = string.Join("", item.FlavourText);
+            }
+
             setProphecyProperties(item);
         }
 
@@ -87,8 +93,6 @@ namespace Procurement.ViewModel
             this.IsProphecy = true;
             this.ProphecyText = prophecy.ProphecyText;
             this.ProphecyDifficultyText = prophecy.ProphecyDifficultyText;
-            this.ProphecyFlavour = prophecy.FlavourText;
-            this.DescriptionText = string.Empty;
         }
 
         private void setTypeSpecificProperties(Item item)
@@ -110,16 +114,6 @@ namespace Procurement.ViewModel
             this.ItemLevel = string.Format("Item Level : {0}", item.ItemLevel);
             this.Requirements = gear.Requirements;
             this.ImplicitMods = gear.Implicitmods;
-
-            if (gear.FlavourText != null && gear.FlavourText.Count > 0)
-            {
-                var builder = new StringBuilder();
-
-                foreach (var text in ((Gear)(item)).FlavourText)
-                    builder.Append(text);
-
-                DescriptionText = builder.ToString();
-            }
         }
     }
 }


### PR DESCRIPTION
The `FlavourText` property was only being given to some subclasses of `Item`, but that missed some item types, such as Pantheon Souls.  This PR promotes `FlavourText` to be a property of `Item`, and it is displayed in the item tooltip whenever it is present.

This PR also reworks how the sections of the item tooltip are assembled.  It is more correct now in terms of being more inclusive.  There are still some known issues, including having an extra divider at the bottom of the tooltip, when the item does not have description text.  Since it more correctly displays the actual text, I think this is an improvement for now.  I have some ideas for how to further improve the item tooltip and handle these known issues.  I don't like working with GUIs, though....