### PR TITLE
Added support to refresh only used tabs.

### DIFF
--- a/Procurement/View/RefreshView.xaml.cs
+++ b/Procurement/View/RefreshView.xaml.cs
@@ -21,6 +21,16 @@ namespace Procurement.View
 
         public void RefreshAllTabs()
         {
+            RefreshTabs(true);
+        }
+
+        public void RefreshUsedTabs()
+        {
+            RefreshTabs(false);
+        }
+
+        public void RefreshTabs(bool refreshAllTabs)
+        {
             statusController = new StatusController(StatusBox, 140);
 
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
@@ -32,14 +42,24 @@ namespace Procurement.View
                 {
                     ApplicationState.Model.StashLoading += model_StashLoading;
                     ApplicationState.Model.Throttled += model_Throttled;
-                    ApplicationState.Stash[ApplicationState.CurrentLeague].RefreshAll(ApplicationState.Model, ApplicationState.CurrentLeague, ApplicationState.AccountName);
+                    if (refreshAllTabs)
+                    {
+                        ApplicationState.Stash[ApplicationState.CurrentLeague].RefreshAll(ApplicationState.Model,
+                            ApplicationState.CurrentLeague, ApplicationState.AccountName);
+                    }
+                    else
+                    {
+                        ApplicationState.Stash[ApplicationState.CurrentLeague].RefreshUsedTabs(ApplicationState.Model,
+                            ApplicationState.CurrentLeague, ApplicationState.AccountName);
+                    }
                     ApplicationState.Model.StashLoading -= model_StashLoading;
                     ApplicationState.Model.Throttled -= model_Throttled;
                 }
                 catch (Exception ex)
                 {
-                    Logger.Log("Exception refreshing all tabs: " + ex.ToString());
-                    MessageBox.Show("Error encountered during refreshing all tabs, error details logged to DebugInfo.log", "Error refreshing all tabs", MessageBoxButton.OK, MessageBoxImage.Error);
+                    Logger.Log("Exception bulk refreshing tabs: " + ex.ToString());
+                    MessageBox.Show("Error encountered during refreshing tabs; error details logged to DebugInfo.log",
+                        "Error refreshing tabs", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
                 finally
                 {
@@ -56,7 +76,8 @@ namespace Procurement.View
         void model_Throttled(object sender, ThottledEventArgs e)
         {
             if (e.WaitTime.TotalSeconds > 4)
-                update(string.Format("GGG Server request limit hit, throttling activated. Please wait {0} seconds", e.WaitTime.Seconds), new POEEventArgs(POEEventState.BeforeEvent));
+                update(string.Format("GGG Server request limit hit, throttling activated. Please wait {0} seconds",
+                    e.WaitTime.Seconds), new POEEventArgs(POEEventState.BeforeEvent));
         }
 
         private void update(string message, POEEventArgs e)

--- a/Procurement/View/StashView.xaml
+++ b/Procurement/View/StashView.xaml
@@ -163,6 +163,7 @@
                     <RowDefinition />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="25px" />
+                    <RowDefinition Height="25px" />
                 </Grid.RowDefinitions>
                 <Border Grid.Row="0" BorderBrush="#FF76591B" BorderThickness="2" Background="Black" Margin="0,10,0,0" Padding="0,5,0,7">
                     <Grid Margin="5,0,11,0" Grid.Row="2" HorizontalAlignment="Left">
@@ -303,6 +304,9 @@
 
                 <Grid Grid.Row="2" Grid.Column="2">
                     <Button Content="Refresh All Tabs" Style="{Binding}" Margin="2,2,2,0" Command="{Binding RefreshCommand}" IsEnabled="{Binding LoggedIn}"/>
+                </Grid>
+                <Grid Grid.Row="3" Grid.Column="2">
+                    <Button Content="Refresh Used Tabs" Style="{Binding}" Margin="2,2,2,0" Command="{Binding RefreshUsedCommand}" IsEnabled="{Binding LoggedIn}"/>
                 </Grid>
             </Grid>
         </Grid>

--- a/Procurement/ViewModel/ScreenController.cs
+++ b/Procurement/ViewModel/ScreenController.cs
@@ -132,6 +132,14 @@ namespace Procurement.ViewModel
             (mainView.MainRegion.Children[0] as RefreshView).RefreshAllTabs();
         }
 
+        public void LoadRefreshViewUsed()
+        {
+            mainView.Buttons.Visibility = Visibility.Hidden;
+            mainView.MainRegion.Children.Clear();
+            mainView.MainRegion.Children.Add(new RefreshView());
+            (mainView.MainRegion.Children[0] as RefreshView).RefreshUsedTabs();
+        }
+
         public void ReloadStash()
         {
             Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,

--- a/Procurement/ViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/StashViewModel.cs
@@ -143,6 +143,13 @@ namespace Procurement.ViewModel
             set { refreshCommand = value; }
         }
 
+        private DelegateCommand refreshUsedCommand;
+        public DelegateCommand RefreshUsedCommand
+        {
+            get { return refreshUsedCommand; }
+            set { refreshUsedCommand = value; }
+        }
+
         public StashViewModel(StashView stashView)
         {
             this.stashView = stashView;
@@ -150,6 +157,10 @@ namespace Procurement.ViewModel
             refreshCommand = new DelegateCommand(x =>
             {
                 ScreenController.Instance.LoadRefreshView();
+            });
+            refreshUsedCommand = new DelegateCommand(x =>
+            {
+                ScreenController.Instance.LoadRefreshViewUsed();
             });
 
             categoryFilter = new List<IFilter>();


### PR DESCRIPTION
All tabs until the final non-empty tab is refreshed.

I particularly enjoyed this optimization when I was only using fewer than 42 tabs, but owned more tabs.  In this case, refreshing all tabs would get throttled, but refreshing only used tabs would not and was much quicker.  Now I just hoard way too many items.