### PR TITLE
Fix login hash regex and add login parameters.

### DIFF
--- a/POEApi.Transport/HttpTransport.cs
+++ b/POEApi.Transport/HttpTransport.cs
@@ -26,7 +26,7 @@ namespace POEApi.Transport
         private const string characterURL = @"https://www.pathofexile.com/character-window/get-characters";
         private const string stashURL = @"https://www.pathofexile.com/character-window/get-stash-items?league={0}&tabs=1&tabIndex={1}&accountName={2}";
         private const string inventoryURL = @"http://www.pathofexile.com/character-window/get-items?character={0}&accountName={1}";
-        private const string hashRegEx = "name=\\\"hash\\\" value=\\\"(?<hash>[a-zA-Z0-9]{1,})\\\"";
+        private const string hashRegEx = "name=\\\"hash\\\" value=\\\"(?<hash>[a-zA-Z0-9-]{1,})\\\"";
 
         private const string updateThreadHashEx = "name=\\\"forum_thread\\\" value=\\\"(?<hash>[a-zA-Z0-9]{1,})\\\"";
         private const string bumpThreadHashEx = "name=\\\"forum_post\\\" value=\\\"(?<hash>[a-zA-Z0-9]{1,})\\\"";
@@ -93,7 +93,9 @@ namespace POEApi.Transport
             StringBuilder data = new StringBuilder();
             data.Append("login_email=" + Uri.EscapeDataString(email));
             data.Append("&login_password=" + Uri.EscapeDataString(password.UnWrap()));
+            data.Append("&remember_me=0");
             data.Append("&hash=" + hashValue);
+            data.Append("&login=Login");
 
             byte[] byteData = UTF8Encoding.UTF8.GetBytes(data.ToString());
 


### PR DESCRIPTION
This PR fixes the regex that looks for the hidden `hash` form field, since it appears to now be a longer string with a hyphen separating two alphanumeric (hexadecimal?) strings.  It also adds two more parameters to the login request.  Adding and fixing these request parameters is sufficient to allow me to log in again, but I'm not certain they are all necessary.

Using `&remember_me=1` appears to not work, and I am not sure if this means the Procurement "user" will be logged out after some time and stop working.  However, I think `&remember_me=0` is the default value, so hopefully everything works the same as before.

So, this PR appears to fix #843.  I haven't tested this for any length of time, but I wanted to at least create this PR so it is ready, particularly if other users start having problems logging in.