### PR TITLE
Remove the unecessary "User-Agent: " prefix.

### DIFF
--- a/POEApi.Transport/HttpTransport.cs
+++ b/POEApi.Transport/HttpTransport.cs
@@ -119,7 +119,7 @@ namespace POEApi.Transport
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(new Uri(url));
 
             request.CookieContainer = credentialCookies;
-            request.UserAgent = "User-Agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; InfoPath.3; .NET4.0C; .NET4.0E; .NET CLR 1.1.4322)";
+            request.UserAgent = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; InfoPath.3; .NET4.0C; .NET4.0E; .NET CLR 1.1.4322)";
             request.Method = method.ToString();
             request.Proxy = getProxySettings();
 


### PR DESCRIPTION
The user agent string should not start with "User-Agent: ".  Including this prefix did not cause an issue logging in with Procurement, but it reportedly can cause issues with, for example, firewalls.

Context: [MDN web docs on User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) (with examples!)

Fixes #190.