### PR TITLE
Option to skip refresh on login

### DIFF
--- a/POEApi.Infrastructure/DPAPI.cs
+++ b/POEApi.Infrastructure/DPAPI.cs
@@ -12,6 +12,7 @@ namespace POEApi.Infrastructure
     public static class DPAPI
     {
         private static RNGCryptoServiceProvider rngProvider = new RNGCryptoServiceProvider();
+        private static int saltLengthBytes = 16;
 
         public static string Encrypt(this SecureString secret)
         {
@@ -21,7 +22,7 @@ namespace POEApi.Infrastructure
             IntPtr ptr = Marshal.SecureStringToCoTaskMemUnicode(secret);
             try
             {
-                byte[] entropy = new byte[16];
+                byte[] entropy = new byte[saltLengthBytes];
                 rngProvider.GetBytes(entropy);
 
                 char[] buffer = new char[secret.Length];
@@ -47,16 +48,21 @@ namespace POEApi.Infrastructure
             if (cipher == null) throw new ArgumentNullException("cipher");
 
             byte[] saltInclusive = Convert.FromBase64String(cipher);
-            MemoryStream ms;
+            if (saltInclusive.Length < saltLengthBytes)
+            {
+                var securedString = new SecureString();
+                securedString.MakeReadOnly();
+                return securedString;
+            }
 
-            byte[] entropy;
-            byte[] data;
+            MemoryStream ms;
+            byte[] entropy, data;
 
             using (ms = new MemoryStream(saltInclusive))
             {
                 BinaryReader reader = new BinaryReader(ms, Encoding.Unicode);
-                entropy = reader.ReadBytes(16);
-                data = reader.ReadBytes(saltInclusive.Length - 16);
+                entropy = reader.ReadBytes(saltLengthBytes);
+                data = reader.ReadBytes(saltInclusive.Length - saltLengthBytes);
             }
 
             byte[] decrypted = ProtectedData.Unprotect(data, entropy, DataProtectionScope.CurrentUser);

--- a/POEApi.Model/Settings.cs
+++ b/POEApi.Model/Settings.cs
@@ -141,11 +141,23 @@ namespace POEApi.Model
 
         public static void Save()
         {
+            var userSettingsElements = settingsFile.Elements("UserSettings").Descendants();
             foreach (string key in UserSettings.Keys)
             {
-                XElement update = settingsFile.Elements("UserSettings").Descendants().First(x => x.Attribute("name").Value == key);
                 if (UserSettings[key] != null)
-                    update.Attribute("value").SetValue(UserSettings[key]);
+                {
+                    var elementToUpdate = userSettingsElements.FirstOrDefault(x => x.Attribute("name").Value == key);
+                    if (elementToUpdate != null)
+                    {
+                        elementToUpdate.Attribute("value").SetValue(UserSettings[key]);
+                    }
+                    else
+                    {
+                        var newSetting = new XElement("Setting", new XAttribute("name", key),
+                            new XAttribute("value", UserSettings[key]));
+                        settingsFile.Element("UserSettings").Add(newSetting);
+                    }
+                }
             }
 
             foreach (OrbType key in CurrencyRatios.Keys)

--- a/POEApi.Model/Settings.xml
+++ b/POEApi.Model/Settings.xml
@@ -71,6 +71,7 @@
     <Setting name="CheckForUpdates" value="True" />
     <Setting name="PoeTradeRefreshEnabled" value="false" />
     <Setting name="PoeTradeRefreshUrl" value="" />
+    <Setting name="ForceRefresh" value="True" />
   </UserSettings>
   <ProxySettings>
     <Setting name="Enabled" value="False" />

--- a/POEApi.Model/Settings.xsd
+++ b/POEApi.Model/Settings.xsd
@@ -46,6 +46,7 @@
               <xs:element name="EmbedBuyouts" type="EmbedBuyouts" minOccurs="1" maxOccurs="1" />
               <xs:element name="BuyoutItemsOnlyVisibleInBuyoutsTag" type="BuyoutItemsOnlyVisibleInBuyoutsTag" minOccurs="1" maxOccurs="1" />
               <xs:element name="CheckForUpdates" type="CheckForUpdates" minOccurs="1" maxOccurs="1" />
+              <xs:element name="ForceRefresh" type="ForceRefresh" minOccurs="1" maxOccurs="1" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -144,6 +145,10 @@
   </xs:complexType>
   <xs:complexType name="CheckForUpdates">
     <xs:attribute name="name" fixed="CheckForUpdates" type="xs:string" use="required"/>
+    <xs:attribute name="value" type="xs:boolean" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="ForceRefresh">
+    <xs:attribute name="name" fixed="ForceRefresh" type="xs:string" use="required"/>
     <xs:attribute name="value" type="xs:boolean" use="required"/>
   </xs:complexType>
   <xs:complexType name="Enabled">

--- a/Procurement/View/LoginView.xaml
+++ b/Procurement/View/LoginView.xaml
@@ -2,6 +2,17 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          Height="600" Width="1012">
+    <UserControl.Resources>
+        <Style x:Key="tooltipStyle" TargetType="{x:Type ToolTip}">
+            <Setter Property = "HorizontalOffset" Value="0"/>
+            <Setter Property = "VerticalOffset" Value="5"/>
+            <Setter Property = "Background" Value="Black"/>
+            <Setter Property = "Foreground" Value="White"/>
+            <Setter Property = "FontSize" Value="14"/>
+            <Setter Property = "FontWeight" Value="Normal"/>
+        </Style>
+    </UserControl.Resources>
+
     <Grid x:Name="ViewContent">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="35*"/>
@@ -25,7 +36,8 @@
                     <RowDefinition Height="35"/>
                     <RowDefinition Height="35"/>
                     <RowDefinition Height="30"/>
-                    <RowDefinition Height="130"/>
+                    <RowDefinition Height="30"/>
+                    <RowDefinition Height="100"/>
                 </Grid.RowDefinitions>
 
                 <Label x:Name="lblEmail" Content="Email" Grid.Row="1" Grid.Column="0" FontFamily="../Resources/#Fontin" Foreground="#FFAB9066" FontSize="14" VerticalAlignment="Top" ></Label>
@@ -78,26 +90,31 @@
                         </Grid.ColumnDefinitions>
                         <CheckBox x:Name="useSession" Content="Use SessionID" Margin="0,9,0,0" Height="15" VerticalAlignment="Top" IsChecked="{Binding UseSession}" Foreground="#FFAB9066" FontSize="12" FontWeight="Bold" HorizontalAlignment="Left" Width="Auto"/>
                         <Image x:Name="sessionidQ" Margin="7,4,0,0" Source="/Procurement;component/Images/circleQuestion.png" Stretch="None" Cursor="Hand" ForceCursor="True" MouseLeftButtonDown="sessionidQ_MouseLeftButtonDown" RenderTransformOrigin="3.075,0.702" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Top" ToolTipService.VerticalOffset="5" MouseLeftButtonUp="sessionidQ_MouseLeftButtonUp">
-                            <Image.Resources>
-                                <Style x:Key="sessionidQTooltip" TargetType="{x:Type ToolTip}">
-                                    <Setter Property = "HorizontalOffset" Value="0"/>
-                                    <Setter Property = "VerticalOffset" Value="5"/>
-                                    <Setter Property = "Background" Value="Black"/>
-                                    <Setter Property = "Foreground" Value="White"/>
-                                    <Setter Property = "FontSize" Value="14"/>
-                                    <Setter Property = "FontWeight" Value="Normal"/>
-                                </Style>
-                            </Image.Resources>
                             <Image.ToolTip>
-                                <ToolTip Style="{StaticResource sessionidQTooltip}">
+                                <ToolTip Style="{StaticResource tooltipStyle}">
                                     <TextBlock Text="Please click here to know the way to get SessionID." />
                                 </ToolTip>
                             </Image.ToolTip>
                         </Image>
                     </Grid>
-
                 </Grid>
-
+                <Grid Grid.Row="4" Grid.Column="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180"/>
+                        <ColumnDefinition Width="159"/>
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <CheckBox Grid.Column="1" x:Name="forceRefresh" Content="Refresh on Login" Margin="25,5,0,0"
+                              Height="15" VerticalAlignment="Top" IsChecked="{Binding ForceRefresh}"
+                              Foreground="#FFAB9066" FontSize="12" FontWeight="Bold" HorizontalAlignment="Left"
+                              Width="Auto">
+                        <CheckBox.ToolTip>
+                            <ToolTip Style="{StaticResource tooltipStyle}">
+                                <TextBlock Text="If unchecked, only missing tabs are downloaded." />
+                            </ToolTip>
+                        </CheckBox.ToolTip>
+                    </CheckBox>
+                </Grid>
             </Grid>
 
             <Grid Grid.Row="1">

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -62,6 +62,21 @@ namespace Procurement.ViewModel
             }
         }
 
+        private bool forceRefresh;
+        public bool ForceRefresh
+        {
+            get { return forceRefresh; }
+            set
+            {
+                if (value != forceRefresh)
+                {
+                    forceRefresh = value;
+                    Settings.UserSettings["ForceRefresh"] = value.ToString();
+                    OnPropertyChanged("ForceRefresh");
+                }
+            }
+        }
+
         private void updateButtonLabels(bool useSession)
         {
             if (this.view == null)
@@ -77,6 +92,8 @@ namespace Procurement.ViewModel
 
             UseSession = Settings.UserSettings.ContainsKey("UseSessionID") ?
                 bool.Parse(Settings.UserSettings["UseSessionID"]) : false;
+            ForceRefresh = Settings.UserSettings.ContainsKey("ForceRefresh") ?
+                bool.Parse(Settings.UserSettings["ForceRefresh"]) : true;
 
             Email = Settings.UserSettings["AccountLogin"];
 
@@ -151,7 +168,10 @@ namespace Procurement.ViewModel
                     statusController.DisplayMessage("Fetching account name...");
                     ApplicationState.AccountName = ApplicationState.Model.GetAccountName();
                     statusController.Ok();
-                    ApplicationState.Model.ForceRefresh();
+                    if (ForceRefresh)
+                    {
+                        ApplicationState.Model.ForceRefresh();
+                    }
                     statusController.DisplayMessage("Loading characters...");
                 }
                 else
@@ -259,6 +279,7 @@ namespace Procurement.ViewModel
 
             Settings.UserSettings["AccountLogin"] = Email;
             Settings.UserSettings["UseSessionID"] = useSession.ToString();
+            Settings.UserSettings["ForceRefresh"] = ForceRefresh.ToString();
             if (passwordChanged)
                 Settings.UserSettings["AccountPassword"] = password.Encrypt();
             Settings.Save();

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -23,6 +23,7 @@ namespace Procurement.ViewModel
         public event LoginCompleted OnLoginCompleted;
         public delegate void LoginCompleted();
         private bool formChanged = false;
+        private bool passwordChanged = false;
         private bool useSession;
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -57,6 +58,7 @@ namespace Procurement.ViewModel
                 useSession = value;
                 Settings.UserSettings["UseSessionID"] = value.ToString();
                 updateButtonLabels(useSession);
+                OnPropertyChanged("UseSessionID");
             }
         }
 
@@ -73,15 +75,16 @@ namespace Procurement.ViewModel
         {
             this.view = view as LoginView;
 
-            UseSession = Settings.UserSettings.ContainsKey("UseSessionID") ? bool.Parse(Settings.UserSettings["UseSessionID"]) : false;
+            UseSession = Settings.UserSettings.ContainsKey("UseSessionID") ?
+                bool.Parse(Settings.UserSettings["UseSessionID"]) : false;
 
             Email = Settings.UserSettings["AccountLogin"];
-            this.formChanged = string.IsNullOrEmpty(Settings.UserSettings["AccountPassword"]);
 
-            if (!this.formChanged)
+            if (!string.IsNullOrEmpty(Settings.UserSettings["AccountPassword"]))
                 this.view.txtPassword.Password = string.Empty.PadLeft(8); //For the visuals
 
-            this.view.txtPassword.PasswordChanged += new System.Windows.RoutedEventHandler(txtPassword_PasswordChanged);
+            this.view.txtPassword.PasswordChanged += new RoutedEventHandler(txtPassword_PasswordChanged);
+            PropertyChanged += loginWindow_PropertyChanged;
 
             characterInjector = new CharacterTabInjector();
 
@@ -100,6 +103,12 @@ namespace Procurement.ViewModel
         void txtPassword_PasswordChanged(object sender, System.Windows.RoutedEventArgs e)
         {
             this.formChanged = true;
+            this.passwordChanged = true;
+        }
+
+        void loginWindow_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            this.formChanged = true;
         }
 
         public void Login(bool offline)
@@ -108,7 +117,8 @@ namespace Procurement.ViewModel
 
             if (string.IsNullOrEmpty(Email))
             {
-                MessageBox.Show(string.Format("{0} is required!", useSession ? "Alias" : "Email"), "Error logging in", MessageBoxButton.OK, MessageBoxImage.Stop);
+                MessageBox.Show(string.Format("{0} is required!", useSession ? "Alias" : "Email"), "Error logging in",
+                    MessageBoxButton.OK, MessageBoxImage.Stop);
                 toggleControls();
                 return;
             }
@@ -126,7 +136,11 @@ namespace Procurement.ViewModel
 
             Task.Factory.StartNew(() =>
             {
-                SecureString password = formChanged ? this.view.txtPassword.SecurePassword : Settings.UserSettings["AccountPassword"].Decrypt();
+                // If offline == true, the password is never checked to know if it is correct, but if
+                // passwordChanged == true, the new value is saved to the settings file.  This might not be the
+                // behavior the user expects.
+                SecureString password = passwordChanged ? this.view.txtPassword.SecurePassword :
+                    Settings.UserSettings["AccountPassword"].Decrypt();
                 ApplicationState.Model.Authenticate(Email, password, offline, useSession);
 
                 if (formChanged)
@@ -177,13 +191,18 @@ namespace Procurement.ViewModel
                 ApplicationState.Model.ImageLoading -= model_ImageLoading;
                 ApplicationState.Model.Throttled -= model_Throttled;
                 OnLoginCompleted();
-            }).ContinueWith(t => { Logger.Log(t.Exception.InnerException.ToString()); statusController.HandleError(t.Exception.InnerException.Message, toggleControls); }, TaskContinuationOptions.OnlyOnFaulted);
+            }).ContinueWith(t =>
+            {
+                Logger.Log(t.Exception.InnerException.ToString());
+                statusController.HandleError(t.Exception.InnerException.Message, toggleControls);
+            }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
         private IEnumerable<Item> LoadItems(bool offline, IEnumerable<Character> chars)
         {
             bool downloadOnlyMyLeagues = (Settings.UserSettings.ContainsKey("DownloadOnlyMyLeagues") &&
-                                          bool.TryParse(Settings.UserSettings["DownloadOnlyMyLeagues"], out downloadOnlyMyLeagues) &&
+                                          bool.TryParse(Settings.UserSettings["DownloadOnlyMyLeagues"],
+                                                        out downloadOnlyMyLeagues) &&
                                           downloadOnlyMyLeagues &&
                                           Settings.Lists.ContainsKey("MyLeagues") &&
                                           Settings.Lists["MyLeagues"].Count > 0);
@@ -195,7 +214,8 @@ namespace Procurement.ViewModel
 
                 if (character.Expired)
                 {
-                    statusController.DisplayMessage(Environment.NewLine + "Skipping character " + character.Name + " because the characters name has expired." + Environment.NewLine);
+                    statusController.DisplayMessage(Environment.NewLine + "Skipping character " + character.Name +
+                        " because the character's name has expired." + Environment.NewLine);
                     continue;
                 }
 
@@ -210,8 +230,8 @@ namespace Procurement.ViewModel
             }
 
             if (downloadOnlyMyLeagues && ApplicationState.Characters.Count == 0)
-                throw new Exception("No characters found in the leagues specified. Check spelling or try setting DownloadOnlyMyLeagues to false in settings.");
-
+                throw new Exception("No characters found in the leagues specified. Check spelling or try setting " +
+                    "DownloadOnlyMyLeagues to false in the Settings.xml file.");
 
             characterInjector.Inject();
         }
@@ -238,8 +258,9 @@ namespace Procurement.ViewModel
                 return;
 
             Settings.UserSettings["AccountLogin"] = Email;
-            Settings.UserSettings["AccountPassword"] = password.Encrypt();
             Settings.UserSettings["UseSessionID"] = useSession.ToString();
+            if (passwordChanged)
+                Settings.UserSettings["AccountPassword"] = password.Encrypt();
             Settings.Save();
         }
 
@@ -257,7 +278,8 @@ namespace Procurement.ViewModel
                 return Enumerable.Empty<Item>();
 
             ApplicationState.CurrentLeague = character.League;
-            ApplicationState.Stash[character.League] = ApplicationState.Model.GetStash(character.League, ApplicationState.AccountName);
+            ApplicationState.Stash[character.League] = ApplicationState.Model.GetStash(character.League,
+                ApplicationState.AccountName);
             ApplicationState.Leagues.Add(character.League);
 
             return ApplicationState.Stash[character.League].Get<Item>();


### PR DESCRIPTION
This PR adds an option on the login window to enable/disable forcing refreshing an account's stash tabs.  If the option is disabled, only missing tabs are downloaded while logging in.  This can help particularly in two cases.  First, if the user wants to close and reopen Procurement and not have to reload all tabs, which could be up to date anyway.  Second, if the user has Procurement keep track of multiple leagues, but the user is only going to reference one of those during a play session, he can have Procurement skip refreshing the tabs from all of those leagues, and manually refresh the tabs for the relevant league, after the login process is completed.

However, since the refresh process that can happen during login deletes and rebuilds the entire folder of `bin` files, if the user skips refreshing tabs at login, Procurement will never pick up changes to tab names/colors and tab ordering. (This is more a bug in how tabs are refreshed after logging in.)

I've also added in this PR some more error checking in places, and cleaned up how we determine we need to save the user's settings after modifying the login window's fields.

I'm not that adept with WPF/XAML, so please let me know particularly if I've done anything wrong or silly regarding the UI.