### PR TITLE
Descriptive name for Item and subclasses

### DIFF
--- a/POEApi.Model/AbyssJewel.cs
+++ b/POEApi.Model/AbyssJewel.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace POEApi.Model
 {
     public class AbyssJewel : SocketableItem
@@ -11,26 +13,26 @@ namespace POEApi.Model
 
         public bool Abyssal { get; } = true;
 
-        public override string DescriptiveName
+        protected override Dictionary<string, string> DescriptiveNameComponents
         {
             get
             {
-                // TODO: Reduce code duplication between this class's implementation and AbyssJewel's (they both
-                // have a "Rarity" property that works the same way, but do not inherit it from the same parent class).
-                string qualityString = this.IsQuality ? string.Format("+{0}% Quality, ", this.Quality) : string.Empty;
-                string itemName = this.TypeLine;
-                if (this.Rarity != Rarity.Normal)
+                // TODO: Reduce code duplication between this class's implementation and Gear's (they both have a
+                // "Rarity" property that works the same way, but do not inherit it from the same parent class).
+                var components = base.DescriptiveNameComponents;
+                if (Rarity != Rarity.Normal)
                 {
-                    if (!this.Identified)
+                    if (!Identified)
                     {
-                        itemName = string.Format("Unidentified {0} {1}", this.Rarity, this.TypeLine);
+                        components["name"] = string.Format("Unidentified {0} {1}", Rarity, TypeLine);
                     }
                     else if (this.Rarity != Rarity.Magic)
                     {
-                        itemName = string.Format("\"{0}\", {1} {2}", this.Name, this.Rarity, this.TypeLine);
+                        components["name"] = string.Format("\"{0}\", {1} {2}", Name, Rarity, TypeLine);
                     }
                 }
-                return string.Format("{0}, {1}i{2}", itemName, qualityString, this.ItemLevel);
+
+                return components;
             }
         }
     }

--- a/POEApi.Model/AbyssJewel.cs
+++ b/POEApi.Model/AbyssJewel.cs
@@ -10,5 +10,28 @@ namespace POEApi.Model
         }
 
         public bool Abyssal { get; } = true;
+
+        public override string DescriptiveName
+        {
+            get
+            {
+                // TODO: Reduce code duplication between this class's implementation and AbyssJewel's (they both
+                // have a "Rarity" property that works the same way, but do not inherit it from the same parent class).
+                string qualityString = this.IsQuality ? string.Format("+{0}% Quality, ", this.Quality) : string.Empty;
+                string itemName = this.TypeLine;
+                if (this.Rarity != Rarity.Normal)
+                {
+                    if (!this.Identified)
+                    {
+                        itemName = string.Format("Unidentified {0} {1}", this.Rarity, this.TypeLine);
+                    }
+                    else if (this.Rarity != Rarity.Magic)
+                    {
+                        itemName = string.Format("\"{0}\", {1} {2}", this.Name, this.Rarity, this.TypeLine);
+                    }
+                }
+                return string.Format("{0}, {1}i{2}", itemName, qualityString, this.ItemLevel);
+            }
+        }
     }
 }

--- a/POEApi.Model/Gear.cs
+++ b/POEApi.Model/Gear.cs
@@ -43,27 +43,26 @@ namespace POEApi.Model
             return Sockets.Count();
         }
 
-        public override string DescriptiveName
+        protected override Dictionary<string, string> DescriptiveNameComponents
         {
             get
             {
                 // TODO: Reduce code duplication between this class's implementation and AbyssJewel's (they both
                 // have a "Rarity" property that works the same way, but do not inherit it from the same parent class).
-                string qualityString = this.IsQuality ? string.Format(", +{0}% Quality", this.Quality) : string.Empty;
-                string itemName = /*this.BaseType ??*/ this.TypeLine;
-                if (this.Rarity != Rarity.Normal)
+                var components = base.DescriptiveNameComponents;
+                if (Rarity != Rarity.Normal)
                 {
-                    if (!this.Identified)
+                    if (!Identified)
                     {
-                        itemName = string.Format("Unidentified {0} {1}", this.Rarity, this.TypeLine);
+                        components["name"] = string.Format("Unidentified {0} {1}", Rarity, TypeLine);
                     }
                     else if (this.Rarity != Rarity.Magic)
                     {
-                        itemName = string.Format("\"{0}\", {1} {2}", this.Name, this.Rarity, this.TypeLine);
+                        components["name"] = string.Format("\"{0}\", {1} {2}", Name, Rarity, TypeLine);
                     }
                 }
-                string iLevelString = this.ItemLevel > 0 ? string.Format(", i{0}", this.ItemLevel) : string.Empty;
-                return string.Format("{0}{1}{2}", itemName, qualityString, iLevelString);
+
+                return components;
             }
         }
     }

--- a/POEApi.Model/Gear.cs
+++ b/POEApi.Model/Gear.cs
@@ -42,5 +42,29 @@ namespace POEApi.Model
         {
             return Sockets.Count();
         }
+
+        public override string DescriptiveName
+        {
+            get
+            {
+                // TODO: Reduce code duplication between this class's implementation and AbyssJewel's (they both
+                // have a "Rarity" property that works the same way, but do not inherit it from the same parent class).
+                string qualityString = this.IsQuality ? string.Format(", +{0}% Quality", this.Quality) : string.Empty;
+                string itemName = /*this.BaseType ??*/ this.TypeLine;
+                if (this.Rarity != Rarity.Normal)
+                {
+                    if (!this.Identified)
+                    {
+                        itemName = string.Format("Unidentified {0} {1}", this.Rarity, this.TypeLine);
+                    }
+                    else if (this.Rarity != Rarity.Magic)
+                    {
+                        itemName = string.Format("\"{0}\", {1} {2}", this.Name, this.Rarity, this.TypeLine);
+                    }
+                }
+                string iLevelString = this.ItemLevel > 0 ? string.Format(", i{0}", this.ItemLevel) : string.Empty;
+                return string.Format("{0}{1}{2}", itemName, qualityString, iLevelString);
+            }
+        }
     }
 }

--- a/POEApi.Model/Gear.cs
+++ b/POEApi.Model/Gear.cs
@@ -58,7 +58,9 @@ namespace POEApi.Model
                     }
                     else if (this.Rarity != Rarity.Magic)
                     {
-                        components["name"] = string.Format("\"{0}\", {1} {2}", Name, Rarity, TypeLine);
+                        string quotedName = string.IsNullOrWhiteSpace(Name) ? string.Empty :
+                            string.Format("\"{0}\", ", Name);
+                        components["name"] = string.Format("{0}{1} {2}", quotedName, Rarity, TypeLine);
                     }
                 }
 

--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -131,10 +131,35 @@ namespace POEApi.Model
         {
             get
             {
-                string qualityString = this.IsQuality ? string.Format(", +{0}% Quality", this.Quality) : string.Empty;
-                string iLevelString = this.ItemLevel > 0 ? string.Format(", i{0}", this.ItemLevel) : string.Empty;
-                return string.Format("{0}{1}{2}", this.TypeLine, qualityString, iLevelString);
+                return AssembleDescriptiveName();
             }
+        }
+
+        protected virtual Dictionary<string, string> DescriptiveNameComponents
+        {
+            get
+            {
+                // TODO: Use a persistent Dictionary that we do not need to recreate for every call.  But this would
+                // require reworking the class in multiple places and in the (applicable) getters, so it would not be
+                // trivial.  Could make the recreation "lazy", however, by just setting a "dirty" flag in the property
+                // setters, and recreating the Dictionary if the data is dirty.
+                return new Dictionary<string, string>
+                {
+                    { "quality", IsQuality ? string.Format("+{0}% Quality", Quality) : null },
+                    { "iLevel",  ItemLevel > 0 ? string.Format("i{0}", ItemLevel) : null },
+                    { "name", TypeLine },
+                };
+            }
+        }
+
+        protected virtual string AssembleDescriptiveName()
+        {
+            var parts = DescriptiveNameComponents;
+            var orderedParts = new List<string>
+            {
+                parts["name"], parts["quality"], parts["iLevel"]
+            }.Where(i => !string.IsNullOrWhiteSpace(i));
+            return string.Join(", ", orderedParts);
         }
 
         public object Clone()

--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace POEApi.Model
@@ -22,6 +23,7 @@ namespace POEApi.Model
         Relic
     }
 
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract class Item : ICloneable
     {
         public string Id { get; set; }
@@ -127,6 +129,9 @@ namespace POEApi.Model
             return Rarity.Normal;
         }
 
+        // TODO: Allow providing a format string in another function, so how an Item is presented can be customized.
+        //       Something similar to (but not as extreme as) the DateTime class' ToString() method.
+        // (See: https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings)
         public virtual string DescriptiveName
         {
             get
@@ -165,6 +170,14 @@ namespace POEApi.Model
         public object Clone()
         {
             return this.MemberwiseClone();
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return AssembleDescriptiveName();
+            }
         }
     }
 }

--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -127,6 +127,16 @@ namespace POEApi.Model
             return Rarity.Normal;
         }
 
+        public virtual string DescriptiveName
+        {
+            get
+            {
+                string qualityString = this.IsQuality ? string.Format(", +{0}% Quality", this.Quality) : string.Empty;
+                string iLevelString = this.ItemLevel > 0 ? string.Format(", i{0}", this.ItemLevel) : string.Empty;
+                return string.Format("{0}{1}{2}", this.TypeLine, qualityString, iLevelString);
+            }
+        }
+
         public object Clone()
         {
             return this.MemberwiseClone();

--- a/POEApi.Model/UnknownItem.cs
+++ b/POEApi.Model/UnknownItem.cs
@@ -8,12 +8,18 @@
         { }
 
         public UnknownItem(JSONProxy.Item item) : base(item)
-        { }
+        {
+            ItemSource = item;
+        }
 
         public UnknownItem(JSONProxy.Item item, string errorInformation) : this(item)
         {
-            ItemSource = item;
             ErrorInformation = errorInformation;
+        }
+
+        protected override string AssembleDescriptiveName()
+        {
+            return string.Format("{0} {1}", "[Unknown Item]", base.AssembleDescriptiveName()).TrimEnd();
         }
 
         public JSONProxy.Item ItemSource { get; }

--- a/Procurement/Controls/RecipeResults.xaml
+++ b/Procurement/Controls/RecipeResults.xaml
@@ -47,7 +47,7 @@
                                                 </ItemsControl.ItemsPanel>
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
-                                                        <RadioButton Tag="{Binding }" GroupName="Items" Content="{Binding TypeLine}" Foreground="#FFAB9066" Checked="RadioButton_Checked" Margin="5,0,0,0" />
+                                                        <RadioButton Tag="{Binding }" GroupName="Items" Content="{Binding DescriptiveName}" Foreground="#FFAB9066" Checked="RadioButton_Checked" Margin="5,0,0,0" />
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>
                                             </ItemsControl>

--- a/Tests/POEApi.Model.Tests/GearTests.cs
+++ b/Tests/POEApi.Model.Tests/GearTests.cs
@@ -31,14 +31,129 @@ namespace POEApi.Model.Tests
             var tricorneItem = new Gear(tricorneProxyItem);
             tricorneItem.BaseType.Should().Be("Tricorne");
             tricorneItem.GearType.Should().Be(GearType.Helmet);
+            tricorneItem.DescriptiveName.Should().Be("Tricorne");
 
             var nobleTricorneItem = new Gear(NobleTricorneProxyItem);
             nobleTricorneItem.BaseType.Should().Be("Noble Tricorne");
             nobleTricorneItem.GearType.Should().Be(GearType.Helmet);
+            nobleTricorneItem.DescriptiveName.Should().Be("Noble Tricorne");
 
             var sinnerTricorneItem = new Gear(SinnerTricorneProxyItem);
             sinnerTricorneItem.BaseType.Should().Be("Sinner Tricorne");
             sinnerTricorneItem.GearType.Should().Be(GearType.Helmet);
+            sinnerTricorneItem.DescriptiveName.Should().Be("Sinner Tricorne");
+        }
+
+        [TestMethod]
+        public void Item_IdentifiedItems_DescriptiveNameProducesCorrectDescription()
+        {
+            JSONProxy.Item normalProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithItemLevel(10)
+                .WithTypeLine("Tricorne").WithQuality(9);
+            JSONProxy.Item magicProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithItemLevel(15)
+                .WithTypeLine("Noble Tricorne").ThatIsIdentified(false);
+            JSONProxy.Item rareProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithItemLevel(20)
+                .WithTypeLine("Sinner Tricorne").WithQuality(0).ThatIsIdentified(false).WithName("Fantastic Voyage");
+            JSONProxy.Item uniqueProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Unique).WithItemLevel(30)
+                .WithTypeLine("Sinner Tricorne").WithQuality(20).ThatIsIdentified(false)
+                .WithName("Kender's Confidence");
+
+            var normalItem = new Gear(normalProxyItem);
+            normalItem.Quality.Should().Be(9);
+            normalItem.IsQuality.Should().BeTrue();
+            normalItem.Rarity.Should().Be(Rarity.Normal);
+            normalItem.BaseType.Should().Be("Tricorne");
+            normalItem.GearType.Should().Be(GearType.Helmet);
+            normalItem.DescriptiveName.Should().Be("Tricorne, +9% Quality, i10");
+
+            var magicItem = new Gear(magicProxyItem);
+            magicItem.Quality.Should().Be(0);
+            magicItem.IsQuality.Should().BeFalse();
+            magicItem.Rarity.Should().Be(Rarity.Magic);
+            magicItem.BaseType.Should().Be("Noble Tricorne");
+            magicItem.GearType.Should().Be(GearType.Helmet);
+            magicItem.DescriptiveName.Should().Be("Unidentified Magic Noble Tricorne, i15");
+
+            var rareItem = new Gear(rareProxyItem);
+            rareItem.Quality.Should().Be(0);
+            rareItem.IsQuality.Should().BeTrue();
+            rareItem.Rarity.Should().Be(Rarity.Rare);
+            rareItem.BaseType.Should().Be("Sinner Tricorne");
+            rareItem.GearType.Should().Be(GearType.Helmet);
+            rareItem.DescriptiveName.Should().Be("Unidentified Rare Sinner Tricorne, +0% Quality, i20");
+
+            var uniqueItem = new Gear(uniqueProxyItem);
+            uniqueItem.Quality.Should().Be(20);
+            uniqueItem.IsQuality.Should().BeTrue();
+            uniqueItem.Rarity.Should().Be(Rarity.Unique);
+            uniqueItem.BaseType.Should().Be("Sinner Tricorne");
+            uniqueItem.GearType.Should().Be(GearType.Helmet);
+            uniqueItem.DescriptiveName.Should().Be("Unidentified Unique Sinner Tricorne, +20% Quality, i30");
+        }
+
+        [TestMethod]
+        public void Item_UnidentifiedItems_DescriptiveNameProducesCorrectDescription()
+        {
+            JSONProxy.Item identifiedMagicProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic)
+                .WithItemLevel(17).WithQuality(11).WithTypeLine("Noble Tricorne of Wanderlust").ThatIsIdentified(true);
+            JSONProxy.Item identifiedRareProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare)
+                .WithItemLevel(25).WithTypeLine("Sinner Tricorne").ThatIsIdentified(true)
+                .WithName("Fantastic Voyage").WithQuality(1);
+            JSONProxy.Item identifiedUniqueProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Unique)
+                .WithItemLevel(35).WithTypeLine("Sinner Tricorne").ThatIsIdentified(true)
+                .WithName("Kender's Confidence");
+
+            var identifiedMagicItem = new Gear(identifiedMagicProxyItem);
+            identifiedMagicItem.Quality.Should().Be(11);
+            identifiedMagicItem.IsQuality.Should().BeTrue();
+            identifiedMagicItem.Rarity.Should().Be(Rarity.Magic);
+            identifiedMagicItem.BaseType.Should().Be("Noble Tricorne");
+            identifiedMagicItem.GearType.Should().Be(GearType.Helmet);
+            identifiedMagicItem.DescriptiveName.Should().Be("Noble Tricorne of Wanderlust, +11% Quality, i17");
+
+            var identifiedRareItem = new Gear(identifiedRareProxyItem);
+            identifiedRareItem.Quality.Should().Be(1);
+            identifiedRareItem.IsQuality.Should().BeTrue();
+            identifiedRareItem.Rarity.Should().Be(Rarity.Rare);
+            identifiedRareItem.BaseType.Should().Be("Sinner Tricorne");
+            identifiedRareItem.GearType.Should().Be(GearType.Helmet);
+            identifiedRareItem.DescriptiveName.Should().Be(
+                "\"Fantastic Voyage\", Rare Sinner Tricorne, +1% Quality, i25");
+
+            var identifiedUniqueItem = new Gear(identifiedUniqueProxyItem);
+            identifiedUniqueItem.Quality.Should().Be(0);
+            identifiedUniqueItem.IsQuality.Should().BeFalse();
+            identifiedUniqueItem.Rarity.Should().Be(Rarity.Unique);
+            identifiedUniqueItem.BaseType.Should().Be("Sinner Tricorne");
+            identifiedUniqueItem.GearType.Should().Be(GearType.Helmet);
+            identifiedUniqueItem.DescriptiveName.Should().Be("\"Kender's Confidence\", Unique Sinner Tricorne, i35");
+        }
+
+        [TestMethod]
+        public void Item_WithMissingExpectedComponents_DescriptiveNameProducesCorrectDescription()
+        {
+            JSONProxy.Item withoutItemLevelProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare)
+                .WithTypeLine("Sinner Tricorne").ThatIsIdentified(true)
+                .WithName("Fantastic Voyage");
+
+            var withoutItemLevelItem = new Gear(withoutItemLevelProxyItem);
+            withoutItemLevelItem.Quality.Should().Be(0);
+            withoutItemLevelItem.IsQuality.Should().BeFalse();
+            withoutItemLevelItem.Rarity.Should().Be(Rarity.Rare);
+            withoutItemLevelItem.BaseType.Should().Be("Sinner Tricorne");
+            withoutItemLevelItem.GearType.Should().Be(GearType.Helmet);
+            withoutItemLevelItem.DescriptiveName.Should().Be("\"Fantastic Voyage\", Rare Sinner Tricorne");
+
+            JSONProxy.Item withoutItemNameProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare)
+                .WithItemLevel(35).WithTypeLine("Sinner Tricorne").ThatIsIdentified(true)
+                .WithName(null);
+
+            var withoutItemNameItem = new Gear(withoutItemNameProxyItem);
+            withoutItemNameItem.Quality.Should().Be(0);
+            withoutItemNameItem.IsQuality.Should().BeFalse();
+            withoutItemNameItem.Rarity.Should().Be(Rarity.Rare);
+            withoutItemNameItem.BaseType.Should().Be("Sinner Tricorne");
+            withoutItemNameItem.GearType.Should().Be(GearType.Helmet);
+            withoutItemNameItem.DescriptiveName.Should().Be("Rare Sinner Tricorne, i35");
         }
     }
 }

--- a/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
+++ b/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -81,6 +81,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IFilterTests.cs" />
     <Compile Include="UnitTestHelper.cs" />
+    <Compile Include="UnknownItemTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Tests/POEApi.Model.Tests/UnknownItemTests.cs
+++ b/Tests/POEApi.Model.Tests/UnknownItemTests.cs
@@ -1,0 +1,68 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using POEApi.TestHelpers.Builders;
+
+namespace POEApi.Model.Tests
+{
+    [TestClass]
+    public class UnknownItemTests
+    {
+        [TestMethod]
+        public void UnknownItem_EmptyConstructor()
+        {
+            var item = new UnknownItem();
+            item.Quality.Should().Be(0);
+            item.IsQuality.Should().BeFalse();
+            item.TypeLine.Should().BeNull();
+            item.DescriptiveName.Should().Be("[Unknown Item]");
+            item.ItemSource.Should().BeNull();
+            item.ErrorInformation.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void UnknownItem_IdentifiedItems_DescriptiveNameProducesCorrectDescription()
+        {
+            JSONProxy.Item normalProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithItemLevel(10)
+                .WithTypeLine("Tricorne").WithQuality(9);
+            JSONProxy.Item magicProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithItemLevel(15)
+                .WithTypeLine("Noble Tricorne").ThatIsIdentified(false);
+            JSONProxy.Item rareProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithItemLevel(20)
+                .WithTypeLine("Sinner Tricorne").WithQuality(0).ThatIsIdentified(false).WithName("Fantastic Voyage");
+            JSONProxy.Item uniqueProxyItem = Build.A.JsonProxyItem.WithFrameType((int)Rarity.Unique).WithItemLevel(30)
+                .WithTypeLine("Sinner Tricorne").WithQuality(20).ThatIsIdentified(false)
+                .WithName("Kender's Confidence");
+
+            var normalItem = new UnknownItem(normalProxyItem);
+            normalItem.Quality.Should().Be(9);
+            normalItem.IsQuality.Should().BeTrue();
+            normalItem.TypeLine.Should().Be("Tricorne");
+            normalItem.DescriptiveName.Should().Be("[Unknown Item] Tricorne, +9% Quality, i10");
+            normalItem.ItemSource.Should().Be(normalProxyItem);
+            normalItem.ErrorInformation.Should().BeNull();
+
+            var magicItem = new UnknownItem(magicProxyItem);
+            magicItem.Quality.Should().Be(0);
+            magicItem.IsQuality.Should().BeFalse();
+            magicItem.TypeLine.Should().Be("Noble Tricorne");
+            magicItem.DescriptiveName.Should().Be("[Unknown Item] Noble Tricorne, i15");
+            magicItem.ItemSource.Should().Be(magicProxyItem);
+            magicItem.ErrorInformation.Should().BeNull();
+
+            var rareItem = new UnknownItem(rareProxyItem);
+            rareItem.Quality.Should().Be(0);
+            rareItem.IsQuality.Should().BeTrue();
+            rareItem.TypeLine.Should().Be("Sinner Tricorne");
+            rareItem.DescriptiveName.Should().Be("[Unknown Item] Sinner Tricorne, +0% Quality, i20");
+            rareItem.ItemSource.Should().Be(rareProxyItem);
+            rareItem.ErrorInformation.Should().BeNull();
+
+            var uniqueItem = new UnknownItem(uniqueProxyItem);
+            uniqueItem.Quality.Should().Be(20);
+            uniqueItem.IsQuality.Should().BeTrue();
+            uniqueItem.TypeLine.Should().Be("Sinner Tricorne");
+            uniqueItem.DescriptiveName.Should().Be("[Unknown Item] Sinner Tricorne, +20% Quality, i30");
+            uniqueItem.ItemSource.Should().Be(uniqueProxyItem);
+            uniqueItem.ErrorInformation.Should().BeNull();
+        }
+    }
+}

--- a/Tests/POEApi.TestHelpers/Builders/JSONProxyItemBuilder.cs
+++ b/Tests/POEApi.TestHelpers/Builders/JSONProxyItemBuilder.cs
@@ -110,5 +110,10 @@ namespace POEApi.TestHelpers.Builders
 
             return this;
         }
+
+        public JSONProxyItemBuilder WithQuality(int qualityAmount)
+        {
+            return this.WithProperty("Quality", "+" + qualityAmount, 1);
+        }
     }
 }


### PR DESCRIPTION
Add a "descriptive name" for `Item` objects, which is a combination of various properties, with some logic to skip empty values.  Subclasses can supply additional properties, or change how properties from parent classes are presented.

This right now will be used to improve the text description of `Gear` in the list of recipe results, where rarity, identified state, rare/unique item name, item level, and quality are displayed, in addition to just the base type.  The descriptive name is also used for the `DebuggerDisplay`, so it is easier to quickly identify items when debugging.

Screenshot:
![image](https://user-images.githubusercontent.com/292581/40598198-5f9eb776-6214-11e8-9818-60f2017d112e.png)