### PR TITLE
Invalidate recipes after refreshing all/used tabs.

### DIFF
--- a/Procurement/ViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/StashViewModel.cs
@@ -157,10 +157,12 @@ namespace Procurement.ViewModel
             refreshCommand = new DelegateCommand(x =>
             {
                 ScreenController.Instance.LoadRefreshView();
+                ScreenController.Instance.InvalidateRecipeScreen();
             });
             refreshUsedCommand = new DelegateCommand(x =>
             {
                 ScreenController.Instance.LoadRefreshViewUsed();
+                ScreenController.Instance.InvalidateRecipeScreen();
             });
 
             categoryFilter = new List<IFilter>();


### PR DESCRIPTION
Since the recipes were not being invalidated after refreshing all tabs or all used tabs, the user would need to refresh an individual tab before he could navigate to the Recipes tab and have the recipes updated.