### PR TITLE
Added new divination cards in 3.3.0.

### DIFF
--- a/POEApi.Model/Data.xml
+++ b/POEApi.Model/Data.xml
@@ -1514,6 +1514,7 @@
       <Item name="Gift of the Gemling Queen"/>
       <Item name="Glimmer of Hope"/>
       <Item name="Grave Knowledge"/>
+      <Item name="Harmony of Souls"/>
       <Item name="Her Mask"/>
       <Item name="Heterochromia"/>
       <Item name="Hope"/>
@@ -1522,6 +1523,7 @@
       <Item name="Humility"/>
       <Item name="Hunter's Resolve"/>
       <Item name="Hunter's Reward"/>
+      <Item name="Immortal Resolve"/>
       <Item name="Jack in the Box"/>
       <Item name="Lantador's Lost Love"/>
       <Item name="Last Hope"/>
@@ -1538,6 +1540,7 @@
       <Item name="Might is Right"/>
       <Item name="Mitts"/>
       <Item name="No Traces"/>
+      <Item name="Perfection"/>
       <Item name="Pride Before the Fall"/>
       <Item name="Prosperity"/>
       <Item name="Rain Tempter"/>
@@ -1547,11 +1550,14 @@
       <Item name="Scholar of the Seas"/>
       <Item name="Shard of Fate"/>
       <Item name="Struck by Lightning"/>
+      <Item name="The Admirer"/>
       <Item name="The Aesthete"/>
       <Item name="The Arena Champion"/>
+      <Item name="The Army of Blood"/>
       <Item name="The Artist"/>
       <Item name="The Avenger"/>
       <Item name="The Battle Born"/>
+      <Item name="The Beast"/>
       <Item name="The Betrayal"/>
       <Item name="The Blazing Fire"/>
       <Item name="The Body"/>
@@ -1563,12 +1569,14 @@
       <Item name="The Cataclysm"/>
       <Item name="The Catalyst"/>
       <Item name="The Celestial Justicar"/>
+      <Item name="The Celestial Stone"/>
       <Item name="The Chains that Bind"/>
       <Item name="The Coming Storm"/>
       <Item name="The Conduit"/>
       <Item name="The Cursed King"/>
       <Item name="The Dapper Prodigy"/>
       <Item name="The Dark Mage"/>
+      <Item name="The Darkest Dream"/>
       <Item name="The Deceiver"/>
       <Item name="The Demoness"/>
       <Item name="The Devastator"/>
@@ -1577,6 +1585,7 @@
       <Item name="The Dragon"/>
       <Item name="The Dragon's Heart"/>
       <Item name="The Dreamer"/>
+      <Item name="The Dreamland"/>
       <Item name="The Drunken Aristocrat"/>
       <Item name="The Encroaching Darkness"/>
       <Item name="The Endurance"/>
@@ -1584,6 +1593,7 @@
       <Item name="The Ethereal"/>
       <Item name="The Explorer"/>
       <Item name="The Eye of the Dragon"/>
+      <Item name="The Fathomless Depths"/>
       <Item name="The Feast"/>
       <Item name="The Fiend"/>
       <Item name="The Fletcher"/>
@@ -1596,6 +1606,7 @@
       <Item name="The Gemcutter"/>
       <Item name="The Gentleman"/>
       <Item name="The Gladiator"/>
+      <Item name="The Hale Heart"/>
       <Item name="The Harvester"/>
       <Item name="The Hermit"/>
       <Item name="The Hoarder"/>
@@ -1607,6 +1618,7 @@
       <Item name="The Inventor"/>
       <Item name="The Iron Bard"/>
       <Item name="The Jester"/>
+      <Item name="The Jeweller's Boon"/>
       <Item name="The King's Blade"/>
       <Item name="The King's Heart"/>
       <Item name="The Last One Standing"/>
@@ -1615,6 +1627,8 @@
       <Item name="The Lord in Black"/>
       <Item name="The Lover"/>
       <Item name="The Lunaris Priestess"/>
+      <Item name="The Master"/>
+      <Item name="The Mayor"/>
       <Item name="The Mercenary"/>
       <Item name="The Metalsmith's Gift"/>
       <Item name="The Oath"/>
@@ -1628,14 +1642,17 @@
       <Item name="The Poet"/>
       <Item name="The Polymath"/>
       <Item name="The Porcupine"/>
+      <Item name="The Professor"/>
       <Item name="The Puzzle"/>
       <Item name="The Queen"/>
       <Item name="The Rabid Rhoa"/>
       <Item name="The Realm"/>
       <Item name="The Risk"/>
+      <Item name="The Rite of Elements"/>
       <Item name="The Road to Power"/>
       <Item name="The Ruthless Ceinture"/>
       <Item name="The Saint's Treasure"/>
+      <Item name="The Samurai's Eye"/>
       <Item name="The Scarred Meadow"/>
       <Item name="The Scavenger"/>
       <Item name="The Scholar"/>
@@ -1652,6 +1669,7 @@
       <Item name="The Surgeon"/>
       <Item name="The Surveyor"/>
       <Item name="The Survivalist"/>
+      <Item name="The Sword King's Salute"/>
       <Item name="The Thaumaturgist"/>
       <Item name="The Throne"/>
       <Item name="The Tower"/>
@@ -1659,6 +1677,8 @@
       <Item name="The Trial"/>
       <Item name="The Twins"/>
       <Item name="The Tyrant"/>
+      <Item name="The Undaunted"/>
+      <Item name="The Undisputed"/>
       <Item name="The Union"/>
       <Item name="The Valkyrie"/>
       <Item name="The Valley of Steel Boxes"/>
@@ -1670,6 +1690,7 @@
       <Item name="The Watcher"/>
       <Item name="The Web"/>
       <Item name="The Wind"/>
+      <Item name="The Witch"/>
       <Item name="The Wolf"/>
       <Item name="The Wolf's Shadow"/>
       <Item name="The Wolven King's Bite"/>
@@ -1678,6 +1699,7 @@
       <Item name="The Wrath"/>
       <Item name="The Wretched"/>
       <Item name="Three Faces in the Dark"/>
+      <Item name="Three Voices"/>
       <Item name="Thunderous Skies"/>
       <Item name="Time-Lost Relic"/>
       <Item name="Tranquillity"/>


### PR DESCRIPTION
I know we probably should not have to include a list of Divination Cards in the data XML file, but until they're removed, I want to keep it up to date.  I got the list of new Divination Cards in 3.3.0 from [here](https://www.pathofexile.com/forum/view-thread/2150238).