### PR TITLE
Update trading/recipe tabs after refreshing stash.

### DIFF
--- a/Procurement/View/RefreshView.xaml.cs
+++ b/Procurement/View/RefreshView.xaml.cs
@@ -64,6 +64,8 @@ namespace Procurement.View
                 finally
                 {
                     ScreenController.Instance.ReloadStash();
+                    ScreenController.Instance.RefreshRecipeScreen();
+                    ScreenController.Instance.UpdateTrading();
                 }
             });
         }

--- a/Procurement/ViewModel/ScreenController.cs
+++ b/Procurement/ViewModel/ScreenController.cs
@@ -52,7 +52,13 @@ namespace Procurement.ViewModel
 
         public void UpdateTrading()
         {
-            screens[TRADING_VIEW] = new TradingView();
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,
+                new Action(() =>
+                {
+                    // TODO: As with updating the RecipeView, can we just update the trading view instead of recreating
+                    // it?
+                    screens[TRADING_VIEW] = new TradingView();
+                }));
         }
 
         private void execute(object obj)
@@ -86,6 +92,18 @@ namespace Procurement.ViewModel
         public void InvalidateRecipeScreen()
         {
             screens[RECIPE_VIEW] = null;
+        }
+
+        public void RefreshRecipeScreen()
+        {
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,
+                new Action(() =>
+                {
+                    // TODO: Cause the RecipeResultsViewModel in the RecipeView to refresh its recipes, instead of
+                    // recreating the RecipeView object.  This could perhaps be done by triggering an event, or
+                    // reaching into the view/viewmodel and calling it directly (but that's probably very bad form).
+                    screens[RECIPE_VIEW] = new RecipeView();
+                }));
         }
 
         private void initLogin()

--- a/Procurement/ViewModel/SettingsViewModel.cs
+++ b/Procurement/ViewModel/SettingsViewModel.cs
@@ -205,13 +205,13 @@ namespace Procurement.ViewModel
         internal void RecipeTabChecked(string tabName)
         {
             addToList("IgnoreTabsInRecipes", tabName);
-            ScreenController.Instance.InvalidateRecipeScreen();
+            ScreenController.Instance.RefreshRecipeScreen();
         }
 
         internal void RecipeTabUnchecked(string tabName)
         {
             removeFromList("IgnoreTabsInRecipes", tabName);
-            ScreenController.Instance.InvalidateRecipeScreen();
+            ScreenController.Instance.RefreshRecipeScreen();
         }
 
         private static void addToList(string list, string value)

--- a/Procurement/ViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/StashViewModel.cs
@@ -415,7 +415,7 @@ namespace Procurement.ViewModel
         {                      
             IStashControl stash = getStash(sender);
             stash.RefreshTab(ApplicationState.AccountName);
-            ScreenController.Instance.InvalidateRecipeScreen();
+            ScreenController.Instance.RefreshRecipeScreen();
             ScreenController.Instance.UpdateTrading();
         }
 


### PR DESCRIPTION
When refreshing all/used tabs in the stash, immediately refresh the recipes and trading views, so they are updated right away, not when the user next navigates to those tabs in the UI.

Note: this doesn't really have a practical impact right now, but I have other local changes to Procurement where it updates my loot filter whenever Procurement refreshes the recipes, so this PR makes that update process a lot smoother. (I'll make a PR for that when I've figured out how to not have everything hard-coded and all.  It's *very* ugly.)