### PR TITLE
Recipes' input items grouped by tab

### DIFF
--- a/Procurement/ViewModel/RecipeResultViewModel.cs
+++ b/Procurement/ViewModel/RecipeResultViewModel.cs
@@ -52,7 +52,8 @@ namespace Procurement.ViewModel
         {
             SelectedItem = item;
         }
-        private void updateResults()
+
+        Dictionary<Tab, List<Item>> GetUsableCurrentLeagueItemsByTab()
         {
             Dictionary<Tab, List<Item>> itemsByTab = new Dictionary<Tab, List<Item>>();
             Stash stash = ApplicationState.Stash[ApplicationState.CurrentLeague];
@@ -63,6 +64,12 @@ namespace Procurement.ViewModel
                 itemsByTab.Add(tab, stash.GetItemsByTab(tab.i));
             }
 
+            return itemsByTab;
+        }
+
+        private void updateResults()
+        {
+            Dictionary<Tab, List<Item>> itemsByTab = GetUsableCurrentLeagueItemsByTab();
             Results = manager.Run(itemsByTab);
             if (Results.Count > 0)
                 SelectedItem = Results.Values.First().First().MatchedItems[0];

--- a/Procurement/ViewModel/RecipeResultViewModel.cs
+++ b/Procurement/ViewModel/RecipeResultViewModel.cs
@@ -54,16 +54,16 @@ namespace Procurement.ViewModel
         }
         private void updateResults()
         {
-            List<Item> items = new List<Item>();
+            Dictionary<Tab, List<Item>> itemsByTab = new Dictionary<Tab, List<Item>>();
             Stash stash = ApplicationState.Stash[ApplicationState.CurrentLeague];
 
             var usableTabs = stash.Tabs.Where(t => !Settings.Lists["IgnoreTabsInRecipes"].Contains(t.Name)).ToList();
             foreach (var tab in usableTabs)
             {
-                items.AddRange(stash.GetItemsByTab(tab.i));
+                itemsByTab.Add(tab, stash.GetItemsByTab(tab.i));
             }
 
-            Results = manager.Run(items);
+            Results = manager.Run(itemsByTab);
             if (Results.Count > 0)
                 SelectedItem = Results.Values.First().First().MatchedItems[0];
         }

--- a/Procurement/ViewModel/Recipes/Recipe.cs
+++ b/Procurement/ViewModel/Recipes/Recipe.cs
@@ -28,5 +28,15 @@ namespace Procurement.ViewModel.Recipes
         }
 
         public abstract IEnumerable<RecipeResult> Matches(IEnumerable<Item> items);
+
+        public virtual IEnumerable<RecipeResult> Matches(IDictionary<Tab, List<Item>> items)
+        {
+            List<Item> flatItems = new List<Item>();
+            foreach (var tab in items)
+            {
+                flatItems.AddRange(tab.Value);
+            }
+            return Matches(flatItems);
+        }
     }
 }

--- a/Procurement/ViewModel/Recipes/RecipeManager.cs
+++ b/Procurement/ViewModel/Recipes/RecipeManager.cs
@@ -32,7 +32,7 @@ namespace Procurement.ViewModel.Recipes
             };
         }
 
-        public Dictionary<string, List<RecipeResult>> Run(IEnumerable<Item> items)
+        public Dictionary<string, List<RecipeResult>> Run(IDictionary<Tab, List<Item>> items)
         {
             return known.SelectMany(recipe => recipe.Matches(items))
                         .GroupBy(r => r.Name)


### PR DESCRIPTION
When providing items for recipes to find matches in, keep a mapping between tabs and items.  This will allow recipes to make decisions based on tab properties.  If the recipes have no specific logic to this, they will default to the old behavior (a single list of items).

Note: this is setup for recipes being able to make smarter decisions, such as white-listing or black-listing items based on properties, including limiting some recipes to certain tabs, etc.