### PR TITLE
Allow any minimum match for SameBaseType Recipe.

### DIFF
--- a/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
@@ -12,6 +12,10 @@ namespace Procurement.ViewModel.Recipes
             : base(60)
         { }
 
+        public SameBaseTypeRecipe(decimal minimumMatchPercentage)
+            : base(minimumMatchPercentage)
+        { }
+
         public override string Name
         {
             get { return "1 Orb of Augmentation - Same base type with normal, magic, rare"; }


### PR DESCRIPTION
Add an overload for the SameBaseTypeRecipe constructor to allow a different minimum match percentage for the formula.  This can be used to collect a lot more potential recipes.