### PR TITLE
SameBaseType recipe - avoid more invalid types & more strict conditions

### DIFF
--- a/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
@@ -61,14 +61,19 @@ namespace Procurement.ViewModel.Recipes
                                                                     .GroupBy(g => g.BaseType)
                                                                     .ToDictionary(g => g.Key.ToString(), g => g.ToList());
 
-            Func<Gear, bool> emptyConstraint = g => true;
             Func<Gear, bool> qualityConstraint = g => g.Quality == 20;
+            Func<Gear, bool> identifiedConstraint = g => g.Identified || g.Rarity == Rarity.Normal;
             Func<Gear, bool> unidentifiedConstraint = g => !g.Identified || g.Rarity == Rarity.Normal;
             Func<Gear, bool> qualityAndUnidentifiedConstraint = g => qualityConstraint(g) && unidentifiedConstraint(g);
+
+            Func<Gear, bool> qualityAndIdentifiedConstraint = g => qualityConstraint(g) && identifiedConstraint(g);
+            Func<Gear, bool> notQualityAndUnidentifiedConstraint = g => !qualityConstraint(g) && unidentifiedConstraint(g);
+            Func<Gear, bool> neitherConstraint = g => !qualityConstraint(g) && identifiedConstraint(g);
             IEnumerable<RecipeResult> allResults = new List<RecipeResult>();
 
             foreach (var constraint in new List<Func<Gear, bool>>() {
-                qualityAndUnidentifiedConstraint, qualityConstraint, unidentifiedConstraint, emptyConstraint })
+                qualityAndUnidentifiedConstraint, qualityAndIdentifiedConstraint, notQualityAndUnidentifiedConstraint,
+                neitherConstraint })
             {
                 allResults = allResults.Concat(getNextResult(baseTypeBuckets, constraint));
             }

--- a/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
@@ -8,13 +8,24 @@ namespace Procurement.ViewModel.Recipes
 {
     public class SameBaseTypeRecipe : Recipe
     {
-        public SameBaseTypeRecipe()
-            : base(60)
-        { }
+        private bool _strictConditionChecking;
+        public bool StrictConditionChecking
+        {
+            get
+            {
+                return _strictConditionChecking;
+            }
+            protected set
+            {
+                _strictConditionChecking = value;
+            }
+        }
 
-        public SameBaseTypeRecipe(decimal minimumMatchPercentage)
+        public SameBaseTypeRecipe(decimal minimumMatchPercentage = 60, bool strictRecipeChecking = true)
             : base(minimumMatchPercentage)
-        { }
+        {
+            StrictConditionChecking = strictRecipeChecking;
+        }
 
         public override string Name
         {
@@ -61,6 +72,7 @@ namespace Procurement.ViewModel.Recipes
                                                                     .GroupBy(g => g.BaseType)
                                                                     .ToDictionary(g => g.Key.ToString(), g => g.ToList());
 
+            Func<Gear, bool> emptyConstraint = g => true;
             Func<Gear, bool> qualityConstraint = g => g.Quality == 20;
             Func<Gear, bool> identifiedConstraint = g => g.Identified || g.Rarity == Rarity.Normal;
             Func<Gear, bool> unidentifiedConstraint = g => !g.Identified || g.Rarity == Rarity.Normal;
@@ -69,11 +81,34 @@ namespace Procurement.ViewModel.Recipes
             Func<Gear, bool> qualityAndIdentifiedConstraint = g => qualityConstraint(g) && identifiedConstraint(g);
             Func<Gear, bool> notQualityAndUnidentifiedConstraint = g => !qualityConstraint(g) && unidentifiedConstraint(g);
             Func<Gear, bool> neitherConstraint = g => !qualityConstraint(g) && identifiedConstraint(g);
-            IEnumerable<RecipeResult> allResults = new List<RecipeResult>();
 
-            foreach (var constraint in new List<Func<Gear, bool>>() {
-                qualityAndUnidentifiedConstraint, qualityAndIdentifiedConstraint, notQualityAndUnidentifiedConstraint,
-                neitherConstraint })
+            List<Func<Gear, bool>> variantConstraints;
+            if (StrictConditionChecking)
+            {
+                // Only include items which do not meet more specific requirements.  For example, do not include items
+                // with 20% quality in recipe variants which do not require 20% quality.
+                variantConstraints = new List<Func<Gear, bool>>()
+                {
+                    qualityAndUnidentifiedConstraint, qualityAndIdentifiedConstraint,
+                    notQualityAndUnidentifiedConstraint, neitherConstraint
+                };
+            }
+            else
+            {
+                variantConstraints = new List<Func<Gear, bool>>()
+                {
+                    qualityAndUnidentifiedConstraint, qualityConstraint, unidentifiedConstraint, emptyConstraint
+                };
+            }
+
+            // Since we check for both complete and partial matches for a variant before moving on to the next, less
+            // valuable variant, we might not find complete but less valuable matches, when there is a partial but more
+            // valuable match that uses those items.  We could introduce another option to first check each variant for
+            // complete matches, and then check each variant for partial matches, to favor quantity of matches over
+            // quality of matches.
+
+            IEnumerable<RecipeResult> allResults = new List<RecipeResult>();
+            foreach (var constraint in variantConstraints)
             {
                 allResults = allResults.Concat(getNextResult(baseTypeBuckets, constraint));
             }

--- a/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
@@ -6,7 +6,7 @@ using POEApi.Model;
 
 namespace Procurement.ViewModel.Recipes
 {
-    class SameBaseTypeRecipe : Recipe
+    public class SameBaseTypeRecipe : Recipe
     {
         public SameBaseTypeRecipe()
             : base(60)

--- a/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
+++ b/Procurement/ViewModel/Recipes/SameBaseTypeRecipe.cs
@@ -51,8 +51,11 @@ namespace Procurement.ViewModel.Recipes
 
         public override IEnumerable<RecipeResult> Matches(IEnumerable<POEApi.Model.Item> items)
         {
+            List<GearType> invalidGearType = new List<GearType> { GearType.Flask, GearType.QuestItem,
+                GearType.DivinationCard, GearType.Talisman, GearType.Breachstone, GearType.Leaguestone };
+
             List<Gear> allGear = items.OfType<Gear>()
-                                      .Where(g => g.GearType != GearType.Flask)
+                                      .Where(g => !invalidGearType.Contains(g.GearType))
                                       .ToList();
             Dictionary<string, List<Gear>> baseTypeBuckets = allGear.Where(g => !string.IsNullOrWhiteSpace(g.BaseType))
                                                                     .GroupBy(g => g.BaseType)

--- a/Tests/Procurement.Tests/Procurement.Tests.csproj
+++ b/Tests/Procurement.Tests/Procurement.Tests.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ViewModel\Recipes\RareSetRecipeTests.cs" />
+    <Compile Include="ViewModel\Recipes\SameBaseTypeRecipeTests.cs" />
     <Compile Include="ViewModel\Recipes\SameNameRecipeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Tests/Procurement.Tests/ViewModel/Recipes/SameBaseTypeRecipeTests.cs
+++ b/Tests/Procurement.Tests/ViewModel/Recipes/SameBaseTypeRecipeTests.cs
@@ -28,118 +28,293 @@ namespace Procurement.ViewModel.Recipes.Tests
         [TestMethod]
         public void SameBaseTypeRecipeTests_EmptyInput_NoMatches()
         {
-            List<Item> items = new List<Item>();
-            items.Should().HaveCount(0);
+            foreach (var strictConditions in new List<bool>() { true, false })
+            {
+                List<Item> items = new List<Item>();
+                items.Should().HaveCount(0);
 
-            SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
-            var matches = recipe.Matches(items).ToList();
+                SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
+                var matches = recipe.Matches(items).ToList();
 
-            matches.Should().NotBeNull();
-            matches.Should().HaveCount(0);
+                matches.Should().NotBeNull();
+                matches.Should().HaveCount(0);
+            }
         }
 
         [TestMethod]
         public void SameBaseTypeRecipeTests_OneItem_NoMatches()
         {
-            foreach (var identifiedState in new List<bool>() { true, false })
-            {
-                foreach (var qualityList in _qualityLists)
-                {
-                    List<Item> items = new List<Item>()
+            foreach (var strictConditions in new List<bool>() { true, false })
+                foreach (var identifiedState in new List<bool>() { true, false })
+                    foreach (var qualityList in _qualityLists)
                     {
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("01")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])
-                            .ThatIsIdentified(identifiedState)),
-                    };
-                    items.Should().HaveCount(1);
-                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+                        List<Item> items = new List<Item>()
+                        {
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("01")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])
+                                .ThatIsIdentified(identifiedState)),
+                        };
+                        items.Should().HaveCount(1);
+                        items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
 
-                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
-                    var matches = recipe.Matches(items).ToList();
+                        SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
+                        var matches = recipe.Matches(items).ToList();
 
-                    matches.Should().NotBeNull();
-                    matches.Should().HaveCount(0);
-                }
-            }
+                        matches.Should().NotBeNull();
+                        matches.Should().HaveCount(0);
+                    }
         }
 
         [TestMethod]
         public void SameBaseTypeRecipeTests_TwoItems_PartialMatch()
         {
-            foreach (var identifiedState in new List<bool>() { true, false })
-            {
-                foreach (var qualityList in _qualityLists)
-                {
-                    List<Item> items = new List<Item>()
+            foreach (var strictConditions in new List<bool>() { true, false })
+                foreach (var identifiedState in new List<bool>() { true, false })
+                    foreach (var qualityList in _qualityLists)
                     {
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
-                            .ThatIsIdentified(identifiedState)),
-                    };
-                    items.Should().HaveCount(2);
-                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+                        List<Item> items = new List<Item>()
+                        {
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
+                                .ThatIsIdentified(identifiedState)),
+                        };
+                        items.Should().HaveCount(2);
+                        items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
 
-                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
-                    var matches = recipe.Matches(items).ToList();
+                        SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
+                        var matches = recipe.Matches(items).ToList();
 
-                    matches.Should().NotBeNull();
-                    matches.Should().HaveCount(1);
+                        matches.Should().NotBeNull();
+                        matches.Should().HaveCount(1);
 
-                    var match = matches.ElementAt(0);
-                    match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
-                    match.IsMatch.Should().BeTrue();
-                    match.Missing.Should().HaveCount(1);
-                    match.Missing[0].Should().Be("Item with Rare rarity");
-                    match.MatchedItems.Should().HaveCount(2);
-                    match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
+                        var match = matches.ElementAt(0);
+                        match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                        match.IsMatch.Should().BeTrue();
+                        match.Missing.Should().HaveCount(1);
+                        match.Missing[0].Should().Be("Item with Rare rarity");
+                        match.MatchedItems.Should().HaveCount(2);
+                        match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
 
-                    if (identifiedState)
-                    {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                        if (identifiedState)
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                            else
+                                match.Name.Should().Be(
+                                    "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                        }
                         else
-                            match.Name.Should().Be(
-                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                    "unidentified");
+                            else
+                                match.Name.Should().Be(
+                                    "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                        }
                     }
-                    else
-                    {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
-                                "unidentified");
-                        else
-                            match.Name.Should().Be(
-                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
-                    }
-                }
-            }
         }
 
         [TestMethod]
         public void SameBaseTypeRecipeTests_ThreeItems_FullMatch()
         {
-            foreach (var identifiedState in new List<bool>() { true, false })
-            {
-                foreach (var qualityList in _qualityLists)
+            foreach (var strictConditions in new List<bool>() { true, false })
+                foreach (var identifiedState in new List<bool>() { true, false })
+                    foreach (var qualityList in _qualityLists)
+                    {
+                        List<Item> items = new List<Item>()
+                        {
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
+                                .ThatIsIdentified(identifiedState)),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
+                                .ThatIsIdentified(identifiedState)),
+                        };
+                        items.Should().HaveCount(3);
+                        items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                        SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
+                        var matches = recipe.Matches(items).ToList();
+
+                        matches.Should().NotBeNull();
+                        matches.Should().HaveCount(1);
+
+                        var match = matches.ElementAt(0);
+                        match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                        match.IsMatch.Should().BeTrue();
+                        match.Missing.Should().HaveCount(0);
+                        match.MatchedItems.Should().HaveCount(3);
+                        match.PercentMatch.Should().Be(100M);
+
+                        if (identifiedState)
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                            else
+                                match.Name.Should().Be(
+                                    "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                        }
+                        else
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                    "unidentified");
+                            else
+                                match.Name.Should().Be(
+                                    "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                        }
+                    }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_ThreeItemsDifferentBaseType_PartialMatch()
+        {
+            foreach (var strictConditions in new List<bool>() { true, false })
+                foreach (var identifiedState in new List<bool>() { true, false })
+                    foreach (var qualityList in _qualityLists)
+                    {
+                        List<Item> items = new List<Item>()
+                        {
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
+                                .ThatIsIdentified(identifiedState)),
+                        };
+                        var otherBaseType = new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic)
+                            .WithId("02").WithTypeLine("Battered Hat").WithQuality(qualityList.Value[2])
+                            .ThatIsIdentified(identifiedState));
+                        items.Add(otherBaseType);
+
+                        items.Should().HaveCount(3);
+                        items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                        SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
+                        var matches = recipe.Matches(items).ToList();
+
+                        matches.Should().NotBeNull();
+                        matches.Should().HaveCount(1);
+
+                        var match = matches.ElementAt(0);
+                        match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                        match.IsMatch.Should().BeTrue();
+                        match.Missing.Should().HaveCount(1);
+                        match.Missing[0].Should().Be("Item with Magic rarity");
+                        match.MatchedItems.Should().HaveCount(2);
+                        match.MatchedItems.Should().NotContain(otherBaseType);
+                        match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
+
+                        if (identifiedState)
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                            else
+                                match.Name.Should().Be(
+                                    "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                        }
+                        else
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                    "unidentified");
+                            else
+                                match.Name.Should().Be(
+                                    "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                        }
+                    }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_MultipleItemsSameRarity_OnlyOneOfEachRarity()
+        {
+            foreach (var strictConditions in new List<bool>() { true, false })
+                foreach (var identifiedState in new List<bool>() { true, false })
+                    foreach (var qualityList in _qualityLists)
+                    {
+                        List<Item> items = new List<Item>()
+                        {
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("02")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("03")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
+                                .ThatIsIdentified(identifiedState)),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("04")
+                                .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[3])
+                                .ThatIsIdentified(identifiedState)),
+                        };
+                        items.Should().HaveCount(4);
+                        items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                        SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
+                        var matches = recipe.Matches(items).ToList();
+
+                        matches.Should().NotBeNull();
+                        matches.Should().HaveCount(1);
+
+                        var match = matches.ElementAt(0);
+                        match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                        match.IsMatch.Should().BeTrue();
+                        match.Missing.Should().HaveCount(0);
+                        match.MatchedItems.Should().HaveCount(3);
+                        match.MatchedItems.Select(i => (i as Gear).Rarity).Should().OnlyHaveUniqueItems();
+                        match.PercentMatch.Should().Be(100M);
+
+                        if (identifiedState)
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                            else
+                                match.Name.Should().Be(
+                                    "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                        }
+                        else
+                        {
+                            if (qualityList.Key)
+                                match.Name.Should().Be(
+                                    "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                    "unidentified");
+                            else
+                                match.Name.Should().Be(
+                                    "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                        }
+                    }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_ThreeItemsSomeFullQuality_FindBestMatch()
+        {
+            foreach (var strictConditions in new List<bool>() { true, false })
+                foreach (var identifiedState in new List<bool>() { true, false })
                 {
                     List<Item> items = new List<Item>()
                     {
                         new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                            .WithTypeLine("Iron Hat")),
                         new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
+                            .WithTypeLine("Iron Hat").WithQuality(20)
                             .ThatIsIdentified(identifiedState)),
                         new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
+                            .WithTypeLine("Iron Hat").WithQuality(10)
                             .ThatIsIdentified(identifiedState)),
                     };
                     items.Should().HaveCount(3);
                     items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
 
-                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
                     var matches = recipe.Matches(items).ToList();
 
                     matches.Should().NotBeNull();
@@ -148,38 +323,39 @@ namespace Procurement.ViewModel.Recipes.Tests
                     var match = matches.ElementAt(0);
                     match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
                     match.IsMatch.Should().BeTrue();
-                    match.Missing.Should().HaveCount(0);
-                    match.MatchedItems.Should().HaveCount(3);
-                    match.PercentMatch.Should().Be(100M);
-
-                    if (identifiedState)
+                    if (strictConditions)
                     {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
-                        else
-                            match.Name.Should().Be(
-                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                        // The magic item is not included because it has 20% quality, but the variant being searched
+                        // for requires quality != 20%.
+                        match.Missing.Should().HaveCount(1);
+                        match.Missing[0].Should().Be("Item with Magic rarity");
+                        match.MatchedItems.Should().HaveCount(2);
+                        match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
                     }
                     else
                     {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
-                                "unidentified");
-                        else
-                            match.Name.Should().Be(
-                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                        match.Missing.Should().HaveCount(0);
+                        match.MatchedItems.Should().HaveCount(3);
+                        match.PercentMatch.Should().Be(100M);
+                    }
+
+                    if (identifiedState)
+                    {
+                        match.Name.Should().Be(
+                            "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                    }
+                    else
+                    {
+                        match.Name.Should().Be(
+                            "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
                     }
                 }
-            }
         }
 
         [TestMethod]
-        public void SameBaseTypeRecipeTests_ThreeItemsDifferentBaseType_PartialMatch()
+        public void SameBaseTypeRecipeTests_ThreeItemsSomeIdentified_FindBestMatch()
         {
-            foreach (var identifiedState in new List<bool>() { true, false })
-            {
+            foreach (var strictConditions in new List<bool>() { true, false })
                 foreach (var qualityList in _qualityLists)
                 {
                     List<Item> items = new List<Item>()
@@ -187,13 +363,12 @@ namespace Procurement.ViewModel.Recipes.Tests
                         new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
                             .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
                         new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
-                            .ThatIsIdentified(identifiedState)),
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
+                            .ThatIsIdentified(false)),
                     };
-                    var otherBaseType = new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
-                        .WithTypeLine("Battered Hat").WithQuality(qualityList.Value[2])
-                        .ThatIsIdentified(identifiedState));
-                    items.Add(otherBaseType);
+                    var identifiedItem = new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                        .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1]).ThatIsIdentified(true));
+                    items.Add(identifiedItem);
 
                     items.Should().HaveCount(3);
                     items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
@@ -210,210 +385,52 @@ namespace Procurement.ViewModel.Recipes.Tests
                     match.Missing.Should().HaveCount(1);
                     match.Missing[0].Should().Be("Item with Magic rarity");
                     match.MatchedItems.Should().HaveCount(2);
-                    match.MatchedItems.Should().NotContain(otherBaseType);
+                    match.MatchedItems.Should().NotContain(identifiedItem);
                     match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
 
-                    if (identifiedState)
-                    {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
-                        else
-                            match.Name.Should().Be(
-                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
-                    }
+                    // When not using strict conditions, we still end up with the unidentified variant, since normal-
+                    // quality items count towards the unidentified recipe, and thus we have more than the minimum
+                    // match percentage with the normal and rare items.  The identified variant is never considered,
+                    // since only one item is left, which does not meet the minimum match percentage.
+
+                    if (qualityList.Key)
+                        match.Name.Should().Be(
+                            "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                            "unidentified");
                     else
-                    {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
-                                "unidentified");
-                        else
-                            match.Name.Should().Be(
-                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
-                    }
+                        match.Name.Should().Be(
+                            "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
                 }
-            }
-        }
-
-        [TestMethod]
-        public void SameBaseTypeRecipeTests_MultipleItemsSameRarity_OnlyOneOfEachRarity()
-        {
-            foreach (var identifiedState in new List<bool>() { true, false })
-            {
-                foreach (var qualityList in _qualityLists)
-                {
-                    List<Item> items = new List<Item>()
-                    {
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("02")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])),
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("03")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
-                            .ThatIsIdentified(identifiedState)),
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("04")
-                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[3])
-                            .ThatIsIdentified(identifiedState)),
-                    };
-                    items.Should().HaveCount(4);
-                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
-
-                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
-                    var matches = recipe.Matches(items).ToList();
-
-                    matches.Should().NotBeNull();
-                    matches.Should().HaveCount(1);
-
-                    var match = matches.ElementAt(0);
-                    match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
-                    match.IsMatch.Should().BeTrue();
-                    match.Missing.Should().HaveCount(0);
-                    match.MatchedItems.Should().HaveCount(3);
-                    match.MatchedItems.Select(i => (i as Gear).Rarity).Should().OnlyHaveUniqueItems();
-                    match.PercentMatch.Should().Be(100M);
-
-                    if (identifiedState)
-                    {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
-                        else
-                            match.Name.Should().Be(
-                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
-                    }
-                    else
-                    {
-                        if (qualityList.Key)
-                            match.Name.Should().Be(
-                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
-                                "unidentified");
-                        else
-                            match.Name.Should().Be(
-                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
-                    }
-                }
-            }
-        }
-
-        [TestMethod]
-        public void SameBaseTypeRecipeTests_ThreeItemsSomeFullQuality_FindBestMatch()
-        {
-            foreach (var identifiedState in new List<bool>() { true, false })
-            {
-                List<Item> items = new List<Item>()
-                {
-                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
-                        .WithTypeLine("Iron Hat")),
-                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
-                        .WithTypeLine("Iron Hat").WithQuality(20)
-                        .ThatIsIdentified(identifiedState)),
-                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
-                        .WithTypeLine("Iron Hat").WithQuality(10)
-                        .ThatIsIdentified(identifiedState)),
-                };
-                items.Should().HaveCount(3);
-                items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
-
-                SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
-                var matches = recipe.Matches(items).ToList();
-
-                matches.Should().NotBeNull();
-                matches.Should().HaveCount(1);
-
-                var match = matches.ElementAt(0);
-                match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
-                match.IsMatch.Should().BeTrue();
-                match.Missing.Should().HaveCount(0);
-                match.MatchedItems.Should().HaveCount(3);
-                match.PercentMatch.Should().Be(100M);
-
-                if (identifiedState)
-                {
-                    match.Name.Should().Be(
-                        "1 Orb of Augmentation - Same base type with normal, magic, and rare");
-                }
-                else
-                {
-                    match.Name.Should().Be(
-                        "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
-                }
-            }
-        }
-
-        [TestMethod]
-        public void SameBaseTypeRecipeTests_ThreeItemsSomeIdentified_FindBestMatch()
-        {
-            foreach (var qualityList in _qualityLists)
-            {
-                List<Item> items = new List<Item>()
-                {
-                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
-                        .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
-                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
-                        .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
-                        .ThatIsIdentified(false)),
-                };
-                var identifiedItem = new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
-                    .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1]).ThatIsIdentified(true));
-                items.Add(identifiedItem);
-
-                items.Should().HaveCount(3);
-                items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
-
-                SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
-                var matches = recipe.Matches(items).ToList();
-
-                matches.Should().NotBeNull();
-                matches.Should().HaveCount(1);
-
-                var match = matches.ElementAt(0);
-                match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
-                match.IsMatch.Should().BeTrue();
-                match.Missing.Should().HaveCount(1);
-                match.Missing[0].Should().Be("Item with Magic rarity");
-                match.MatchedItems.Should().HaveCount(2);
-                match.MatchedItems.Should().NotContain(identifiedItem);
-                match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
-
-                if (qualityList.Key)
-                    match.Name.Should().Be(
-                        "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and unidentified");
-                else
-                    match.Name.Should().Be(
-                        "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
-            }
         }
 
         [TestMethod]
         public void SameBaseTypeRecipeTests_InvalidGearType_DoNotUse()
         {
-            foreach (var identifiedState in new List<bool>() { true, false })
-            {
-                foreach (var qualityList in _qualityLists)
-                {
-                    List<Item> items = new List<Item>()
+            foreach (var strictConditions in new List<bool>() { true, false })
+                foreach (var identifiedState in new List<bool>() { true, false })
+                    foreach (var qualityList in _qualityLists)
                     {
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
-                            .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[0])),
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
-                            .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[1])
-                            .ThatIsIdentified(identifiedState)),
-                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
-                            .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[2])
-                            .ThatIsIdentified(identifiedState)),
-                    };
-                    items.Should().HaveCount(3);
-                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
-                    items.Select(i => (i as Gear).GearType).ShouldAllBeEquivalentTo(GearType.Flask);
+                        List<Item> items = new List<Item>()
+                        {
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                                .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[0])),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                                .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[1])
+                                .ThatIsIdentified(identifiedState)),
+                            new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                                .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[2])
+                                .ThatIsIdentified(identifiedState)),
+                        };
+                        items.Should().HaveCount(3);
+                        items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+                        items.Select(i => (i as Gear).GearType).ShouldAllBeEquivalentTo(GearType.Flask);
 
-                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
-                    var matches = recipe.Matches(items).ToList();
+                        SameBaseTypeRecipe recipe = new SameBaseTypeRecipe(60, strictConditions);
+                        var matches = recipe.Matches(items).ToList();
 
-                    matches.Should().NotBeNull();
-                    matches.Should().HaveCount(0);
-                }
-            }
+                        matches.Should().NotBeNull();
+                        matches.Should().HaveCount(0);
+                    }
         }
     }
 }

--- a/Tests/Procurement.Tests/ViewModel/Recipes/SameBaseTypeRecipeTests.cs
+++ b/Tests/Procurement.Tests/ViewModel/Recipes/SameBaseTypeRecipeTests.cs
@@ -1,0 +1,419 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using POEApi.Model;
+using POEApi.TestHelpers.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Procurement.ViewModel.Recipes.Tests
+{
+    [TestClass]
+    public class SameBaseTypeRecipeTests
+    {
+        static protected Dictionary<bool, List<int>> _qualityLists;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _qualityLists = new Dictionary<bool, List<int>>()
+            {
+                { false, new List<int>() { 19, 2, 0, 5 } },
+                { true, new List<int>() { 20, 20, 20, 20 } },
+            };
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_EmptyInput_NoMatches()
+        {
+            List<Item> items = new List<Item>();
+            items.Should().HaveCount(0);
+
+            SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+            var matches = recipe.Matches(items).ToList();
+
+            matches.Should().NotBeNull();
+            matches.Should().HaveCount(0);
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_OneItem_NoMatches()
+        {
+            foreach (var identifiedState in new List<bool>() { true, false })
+            {
+                foreach (var qualityList in _qualityLists)
+                {
+                    List<Item> items = new List<Item>()
+                    {
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("01")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])
+                            .ThatIsIdentified(identifiedState)),
+                    };
+                    items.Should().HaveCount(1);
+                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                    var matches = recipe.Matches(items).ToList();
+
+                    matches.Should().NotBeNull();
+                    matches.Should().HaveCount(0);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_TwoItems_PartialMatch()
+        {
+            foreach (var identifiedState in new List<bool>() { true, false })
+            {
+                foreach (var qualityList in _qualityLists)
+                {
+                    List<Item> items = new List<Item>()
+                    {
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
+                            .ThatIsIdentified(identifiedState)),
+                    };
+                    items.Should().HaveCount(2);
+                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                    var matches = recipe.Matches(items).ToList();
+
+                    matches.Should().NotBeNull();
+                    matches.Should().HaveCount(1);
+
+                    var match = matches.ElementAt(0);
+                    match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                    match.IsMatch.Should().BeTrue();
+                    match.Missing.Should().HaveCount(1);
+                    match.Missing[0].Should().Be("Item with Rare rarity");
+                    match.MatchedItems.Should().HaveCount(2);
+                    match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
+
+                    if (identifiedState)
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                        else
+                            match.Name.Should().Be(
+                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                    }
+                    else
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                "unidentified");
+                        else
+                            match.Name.Should().Be(
+                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_ThreeItems_FullMatch()
+        {
+            foreach (var identifiedState in new List<bool>() { true, false })
+            {
+                foreach (var qualityList in _qualityLists)
+                {
+                    List<Item> items = new List<Item>()
+                    {
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
+                            .ThatIsIdentified(identifiedState)),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
+                            .ThatIsIdentified(identifiedState)),
+                    };
+                    items.Should().HaveCount(3);
+                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                    var matches = recipe.Matches(items).ToList();
+
+                    matches.Should().NotBeNull();
+                    matches.Should().HaveCount(1);
+
+                    var match = matches.ElementAt(0);
+                    match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                    match.IsMatch.Should().BeTrue();
+                    match.Missing.Should().HaveCount(0);
+                    match.MatchedItems.Should().HaveCount(3);
+                    match.PercentMatch.Should().Be(100M);
+
+                    if (identifiedState)
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                        else
+                            match.Name.Should().Be(
+                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                    }
+                    else
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                "unidentified");
+                        else
+                            match.Name.Should().Be(
+                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_ThreeItemsDifferentBaseType_PartialMatch()
+        {
+            foreach (var identifiedState in new List<bool>() { true, false })
+            {
+                foreach (var qualityList in _qualityLists)
+                {
+                    List<Item> items = new List<Item>()
+                    {
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])
+                            .ThatIsIdentified(identifiedState)),
+                    };
+                    var otherBaseType = new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                        .WithTypeLine("Battered Hat").WithQuality(qualityList.Value[2])
+                        .ThatIsIdentified(identifiedState));
+                    items.Add(otherBaseType);
+
+                    items.Should().HaveCount(3);
+                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                    var matches = recipe.Matches(items).ToList();
+
+                    matches.Should().NotBeNull();
+                    matches.Should().HaveCount(1);
+
+                    var match = matches.ElementAt(0);
+                    match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                    match.IsMatch.Should().BeTrue();
+                    match.Missing.Should().HaveCount(1);
+                    match.Missing[0].Should().Be("Item with Magic rarity");
+                    match.MatchedItems.Should().HaveCount(2);
+                    match.MatchedItems.Should().NotContain(otherBaseType);
+                    match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
+
+                    if (identifiedState)
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                        else
+                            match.Name.Should().Be(
+                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                    }
+                    else
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                "unidentified");
+                        else
+                            match.Name.Should().Be(
+                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_MultipleItemsSameRarity_OnlyOneOfEachRarity()
+        {
+            foreach (var identifiedState in new List<bool>() { true, false })
+            {
+                foreach (var qualityList in _qualityLists)
+                {
+                    List<Item> items = new List<Item>()
+                    {
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("02")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1])),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("03")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
+                            .ThatIsIdentified(identifiedState)),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("04")
+                            .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[3])
+                            .ThatIsIdentified(identifiedState)),
+                    };
+                    items.Should().HaveCount(4);
+                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                    var matches = recipe.Matches(items).ToList();
+
+                    matches.Should().NotBeNull();
+                    matches.Should().HaveCount(1);
+
+                    var match = matches.ElementAt(0);
+                    match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                    match.IsMatch.Should().BeTrue();
+                    match.Missing.Should().HaveCount(0);
+                    match.MatchedItems.Should().HaveCount(3);
+                    match.MatchedItems.Select(i => (i as Gear).Rarity).Should().OnlyHaveUniqueItems();
+                    match.PercentMatch.Should().Be(100M);
+
+                    if (identifiedState)
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "1 Orb of Alchemy - Same base type with normal, magic, rare, 20% quality");
+                        else
+                            match.Name.Should().Be(
+                                "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                    }
+                    else
+                    {
+                        if (qualityList.Key)
+                            match.Name.Should().Be(
+                                "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and " +
+                                "unidentified");
+                        else
+                            match.Name.Should().Be(
+                                "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_ThreeItemsSomeFullQuality_FindBestMatch()
+        {
+            foreach (var identifiedState in new List<bool>() { true, false })
+            {
+                List<Item> items = new List<Item>()
+                {
+                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                        .WithTypeLine("Iron Hat")),
+                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                        .WithTypeLine("Iron Hat").WithQuality(20)
+                        .ThatIsIdentified(identifiedState)),
+                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                        .WithTypeLine("Iron Hat").WithQuality(10)
+                        .ThatIsIdentified(identifiedState)),
+                };
+                items.Should().HaveCount(3);
+                items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                var matches = recipe.Matches(items).ToList();
+
+                matches.Should().NotBeNull();
+                matches.Should().HaveCount(1);
+
+                var match = matches.ElementAt(0);
+                match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                match.IsMatch.Should().BeTrue();
+                match.Missing.Should().HaveCount(0);
+                match.MatchedItems.Should().HaveCount(3);
+                match.PercentMatch.Should().Be(100M);
+
+                if (identifiedState)
+                {
+                    match.Name.Should().Be(
+                        "1 Orb of Augmentation - Same base type with normal, magic, and rare");
+                }
+                else
+                {
+                    match.Name.Should().Be(
+                        "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_ThreeItemsSomeIdentified_FindBestMatch()
+        {
+            foreach (var qualityList in _qualityLists)
+            {
+                List<Item> items = new List<Item>()
+                {
+                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                        .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[0])),
+                    new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                        .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[2])
+                        .ThatIsIdentified(false)),
+                };
+                var identifiedItem = new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                    .WithTypeLine("Iron Hat").WithQuality(qualityList.Value[1]).ThatIsIdentified(true));
+                items.Add(identifiedItem);
+
+                items.Should().HaveCount(3);
+                items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+
+                SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                var matches = recipe.Matches(items).ToList();
+
+                matches.Should().NotBeNull();
+                matches.Should().HaveCount(1);
+
+                var match = matches.ElementAt(0);
+                match.Instance.Should().BeOfType<SameBaseTypeRecipe>();
+                match.IsMatch.Should().BeTrue();
+                match.Missing.Should().HaveCount(1);
+                match.Missing[0].Should().Be("Item with Magic rarity");
+                match.MatchedItems.Should().HaveCount(2);
+                match.MatchedItems.Should().NotContain(identifiedItem);
+                match.PercentMatch.Should().BeApproximately(200M / 3M, 0.001M);
+
+                if (qualityList.Key)
+                    match.Name.Should().Be(
+                        "2 Orbs of Alchemy - Same base type with normal, magic, rare, 20% quality and unidentified");
+                else
+                    match.Name.Should().Be(
+                        "2 Orbs of Augmentation - Same base type with normal, magic, rare, unidentified");
+            }
+        }
+
+        [TestMethod]
+        public void SameBaseTypeRecipeTests_InvalidGearType_DoNotUse()
+        {
+            foreach (var identifiedState in new List<bool>() { true, false })
+            {
+                foreach (var qualityList in _qualityLists)
+                {
+                    List<Item> items = new List<Item>()
+                    {
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Normal).WithId("01")
+                            .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[0])),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Magic).WithId("02")
+                            .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[1])
+                            .ThatIsIdentified(identifiedState)),
+                        new Gear(Build.A.JsonProxyItem.WithFrameType((int)Rarity.Rare).WithId("03")
+                            .WithTypeLine("Small Life Flask").WithQuality(qualityList.Value[2])
+                            .ThatIsIdentified(identifiedState)),
+                    };
+                    items.Should().HaveCount(3);
+                    items.Select(i => i.Id).Should().OnlyHaveUniqueItems();
+                    items.Select(i => (i as Gear).GearType).ShouldAllBeEquivalentTo(GearType.Flask);
+
+                    SameBaseTypeRecipe recipe = new SameBaseTypeRecipe();
+                    var matches = recipe.Matches(items).ToList();
+
+                    matches.Should().NotBeNull();
+                    matches.Should().HaveCount(0);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Avoid checking more `GearType` which can not be used in this recipe, such as Divination Cards.  These will never end up in a recipe result anyway, but filtering them out in the beginning should speed up searching for candidates.

Also, change the conditions checked to be disjoint subsets across the 2D space of `({ Identified, Unidentified }, { 20% Quality, <20% Quality })`.  Practically, the only difference will be that 20% quality items will not be included in recipes that do not require 20% quality.  The old behavior can still be used by using a non-default constructor parameter value.

Unit tests! 🎉