### PR TITLE
Handle null shop thread values

### DIFF
--- a/POEApi.Model/Settings.cs
+++ b/POEApi.Model/Settings.cs
@@ -251,6 +251,7 @@ namespace POEApi.Model
         {
             try
             {
+                bool success = true;
                 if (!settingsFile.Elements("ShopSettings").Any())
                     settingsFile.Add(new XElement("ShopSettings"));
 
@@ -258,12 +259,23 @@ namespace POEApi.Model
 
                 foreach (var shop in ShopSettings)
                 {
-                    XElement buyout = new XElement("Shop", new XAttribute("League", shop.Key), new XAttribute("ThreadId", shop.Value.ThreadId), new XAttribute("ThreadTitle", shop.Value.ThreadTitle));
+                    if (shop.Value == null)
+                    {
+                        Logger.Log(string.Format("Shop settings for league {0} is null while trying to save settings.",
+                            shop.Key));
+                        success = false;
+                        continue;
+                    }
+
+                    XElement buyout = new XElement("Shop",
+                        new XAttribute("League", shop.Key),
+                        new XAttribute("ThreadId", shop.Value.ThreadId),
+                        new XAttribute("ThreadTitle", shop.Value.ThreadTitle));
                     settingsFile.Element("ShopSettings").Add(buyout);
                 }
 
                 settingsFile.Save(SAVE_LOCATION);
-                return true;
+                return success;
             }
             catch (Exception ex)
             {

--- a/Procurement/ViewModel/TradeSettingsViewModel.cs
+++ b/Procurement/ViewModel/TradeSettingsViewModel.cs
@@ -153,8 +153,8 @@ namespace Procurement.ViewModel
             if (!Settings.ShopSettings.ContainsKey(ApplicationState.CurrentLeague))
                 Settings.ShopSettings.Add(ApplicationState.CurrentLeague, new ShopSetting());
 
-            Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId = this.threadId;
-            Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle = this.threadTitle;
+            Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId = this.threadId ?? "";
+            Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle = this.threadTitle ?? "";
 
             if (Settings.SaveShopSettings())
                 MessageBox.Show("Shop settings saved", "Settings saved", MessageBoxButton.OK, MessageBoxImage.Information);


### PR DESCRIPTION
This PR adds a bunch of error handling when trying to save shop settings information.  It should fix #884, but I can't say for sure, since the error message is vague and the referenced line is really, really long.  If it does not, we will probably have more error information logged to investigate further.