### PR TITLE
Use generic hash regex when updating shops.

### DIFF
--- a/POEApi.Infrastructure/ForumThreadException.cs
+++ b/POEApi.Infrastructure/ForumThreadException.cs
@@ -3,5 +3,11 @@
 namespace POEApi.Infrastructure
 {
     public class ForumThreadException : Exception
-    { }
+    {
+        public ForumThreadException()
+            : base() { }
+
+        public ForumThreadException(string message)
+            : base(message) { }
+    }
 }

--- a/Procurement/ViewModel/ForumExportViewModel.cs
+++ b/Procurement/ViewModel/ForumExportViewModel.cs
@@ -145,16 +145,23 @@ namespace Procurement.ViewModel
                 {
                     try
                     {
-                        var threadBumped = ApplicationState.Model.BumpThread(Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId, Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle);
+                        var threadBumped = ApplicationState.Model.BumpThread(
+                            Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId,
+                            Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle);
 
                         if (threadBumped)
-                            MessageBox.Show("Shop thread successfully bumped!", "Thread bumped", MessageBoxButton.OK, MessageBoxImage.Information);
+                            MessageBox.Show("Shop thread successfully bumped!", "Thread bumped", MessageBoxButton.OK,
+                                MessageBoxImage.Information);
                         else
-                            MessageBox.Show("Error bumping shop thread, details logged to debuginfo.log", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            MessageBox.Show("Error bumping shop thread, details logged to debuginfo.log", "Error",
+                                MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                     catch (ForumThreadException)
                     {
-                        MessageBox.Show("The thread title supplied in your settings does not match the title of the thread Procurement tried to bump with the threadId in your settings. Check that your settings are correct", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show("There was an error while attempting to bump the thread.  It is possible " +
+                            "the thread title supplied in your settings does not match the title of the thread " +
+                            "Procurement tried to bump with the threadId in your settings. Check that your settings " +
+                            "are correct", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                     }
                 });
         }
@@ -186,7 +193,9 @@ namespace Procurement.ViewModel
 
         private bool settingsValid(bool isUpdate)
         {
-            if (!Settings.ShopSettings.ContainsKey(ApplicationState.CurrentLeague) || string.IsNullOrEmpty(Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId) || string.IsNullOrEmpty(Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle))
+            if (!Settings.ShopSettings.ContainsKey(ApplicationState.CurrentLeague) ||
+                string.IsNullOrEmpty(Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadId) ||
+                string.IsNullOrEmpty(Settings.ShopSettings[ApplicationState.CurrentLeague].ThreadTitle))
             {
                 MessageBox.Show("No shop settings found for current league, please configure your ThreadId and ThreadTitle under the TradeSettings tab", "Settings not found!", MessageBoxButton.OK, MessageBoxImage.Error);
                 return false;


### PR DESCRIPTION
Similar to how the hash for the login page was change in a recent league, the hash for editing threads and posting replies has changed for 3.4 (Delve).  Use the same regex to find the hash in all of these situations.

I've also taken the liberty of cleaning up some of the code and how errors are handled.  It is possible to (probably reliably) check if the actual edit/post action was successful, so I added some TODOs to add that functionality.

Fixes #882.