### PR TITLE
Session id with cloudflare

### DIFF
--- a/POEApi.Transport/CachedTransport.cs
+++ b/POEApi.Transport/CachedTransport.cs
@@ -17,6 +17,19 @@ namespace POEApi.Transport
 
         public event ThottledEventHandler Throttled;
 
+        private string _userAgent;
+        public string UserAgent
+        {
+            get
+            {
+                return innerTranport.UserAgent;
+            }
+            set
+            {
+                innerTranport.UserAgent = value;
+            }
+        }
+
         public CachedTransport(string email, ITransport innerTranport, bool offline)
         {
             Offline = offline;
@@ -32,9 +45,10 @@ namespace POEApi.Transport
                 Throttled(sender, e);
         }
 
-        public bool Authenticate(string email, SecureString password, bool useSessionID)
+        public bool Authenticate(string email, SecureString password, bool useSessionID, string cloudFlareId,
+            string cloudFlareClearance)
         {
-            return innerTranport.Authenticate(email, password, useSessionID);
+            return innerTranport.Authenticate(email, password, useSessionID, cloudFlareId, cloudFlareClearance);
         }
 
         public Stream GetAccountName()

--- a/POEApi.Transport/CachedTransport.cs
+++ b/POEApi.Transport/CachedTransport.cs
@@ -17,7 +17,6 @@ namespace POEApi.Transport
 
         public event ThottledEventHandler Throttled;
 
-        private string _userAgent;
         public string UserAgent
         {
             get

--- a/POEApi.Transport/HttpTransport.cs
+++ b/POEApi.Transport/HttpTransport.cs
@@ -42,18 +42,7 @@ namespace POEApi.Transport
 
         private static TaskThrottle taskThrottle = new TaskThrottle(TimeSpan.FromMinutes(1), 42, 42);
 
-        private string _userAgent;
-        public string UserAgent
-        {
-            get
-            {
-                return _userAgent;
-            }
-            set
-            {
-                _userAgent = value;
-            }
-        }
+        public string UserAgent { get; set; }
 
         public HttpTransport(string login)
         {

--- a/POEApi.Transport/ITransport.cs
+++ b/POEApi.Transport/ITransport.cs
@@ -6,7 +6,9 @@ namespace POEApi.Transport
 {
     public interface ITransport
     {
-        bool Authenticate(string email, SecureString password, bool useSessionID);
+        string UserAgent { get; set; }
+        bool Authenticate(string email, SecureString password, bool useSessionID, string cloudFlareId,
+            string cloudFlareClearance);
         Stream GetAccountName();
         Stream GetStash(int index, string league, string accountName);
         Stream GetStash(int index, string league, string accountName, bool refresh);

--- a/Procurement/View/LoginView.xaml
+++ b/Procurement/View/LoginView.xaml
@@ -71,6 +71,19 @@
                          Background="Black" BorderBrush="#FF76591B" Foreground="#FFAB9066" SelectionBrush="#FFCABE9F">
                 </TextBox>
 
+                <Image x:Name="userAgentQ" Margin="7,4,0,0" Source="/Procurement;component/Images/circleQuestion.png"
+                       Stretch="None" Cursor="Hand" ForceCursor="True" RenderTransformOrigin="3.075,0.702" Grid.Row="3"
+                       Grid.Column="2" HorizontalAlignment="Left" VerticalAlignment="Top"
+                       ToolTipService.VerticalOffset="5" MouseLeftButtonDown="userAgentQ_MouseLeftButtonDown"
+                       MouseLeftButtonUp="userAgentQ_MouseLeftButtonUp">
+                    <Image.ToolTip>
+                        <ToolTip Style="{StaticResource tooltipStyle}">
+                            <TextBlock Width="300" TextWrapping="Wrap"
+                                       Text="The user agent of the browser used to obtain the Session ID.  Click here to open a web page to see what your user agent is.  Paste that value in this text box." />
+                        </ToolTip>
+                    </Image.ToolTip>
+                </Image>
+
                 <Image x:Name="cloudFlareIdQ" Margin="7,4,0,0" Source="/Procurement;component/Images/circleQuestion.png"
                        Stretch="None" RenderTransformOrigin="3.075,0.702" Grid.Row="4" Grid.Column="2"
                        HorizontalAlignment="Left" VerticalAlignment="Top" ToolTipService.VerticalOffset="5">

--- a/Procurement/View/LoginView.xaml
+++ b/Procurement/View/LoginView.xaml
@@ -28,11 +28,15 @@
             </Grid.RowDefinitions>
             <Grid Grid.Row="0">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="100"/>
-                    <ColumnDefinition />
+                    <ColumnDefinition Width="110"/>
+                    <ColumnDefinition Width="330"/>
+                    <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="60"/>
+                    <RowDefinition Height="35"/>
+                    <RowDefinition Height="35"/>
+                    <RowDefinition Height="35"/>
                     <RowDefinition Height="35"/>
                     <RowDefinition Height="35"/>
                     <RowDefinition Height="30"/>
@@ -42,11 +46,53 @@
 
                 <Label x:Name="lblEmail" Content="Email" Grid.Row="1" Grid.Column="0" FontFamily="../Resources/#Fontin" Foreground="#FFAB9066" FontSize="14" VerticalAlignment="Top" ></Label>
                 <Label x:Name="lblPassword" Content="Password" Grid.Row="2" Grid.Column="0" FontFamily="../Resources/#Fontin" Foreground="#FFAB9066" FontSize="14" VerticalAlignment="Top" ></Label>
+                <Label x:Name="lblUserAgent" Content="UserAgent" Grid.Row="3" Grid.Column="0"
+                       FontFamily="../Resources/#Fontin" Foreground="#FFAB9066" FontSize="14" VerticalAlignment="Top">
+                </Label>
+                <Label x:Name="lblCloudFlareId" Content="CloudFlare ID" Grid.Row="4" Grid.Column="0"
+                       FontFamily="../Resources/#Fontin" Foreground="#FFAB9066" FontSize="14" VerticalAlignment="Top" >
+                </Label>
+                <Label x:Name="lblCloudFlareClearance" Content="CloudFlare PW" Grid.Row="5" Grid.Column="0"
+                       FontFamily="../Resources/#Fontin" Foreground="#FFAB9066" FontSize="14" VerticalAlignment="Top" >
+                </Label>
 
                 <TextBox Name="txtLogin" Text="{Binding Email}" Grid.Row="1" Grid.Column="1" Height="22" Width="330" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Black" BorderBrush="#FF76591B" Foreground="#FFAB9066" SelectionBrush="#FFCABE9F"></TextBox>
                 <PasswordBox Name="txtPassword" Grid.Row="2" Grid.Column="1" Height="22" Width="330" Background="Black" BorderBrush="#FF76591B" HorizontalAlignment="Left" VerticalAlignment="Top"  Foreground="#FFAB9066" SelectionBrush="#FFCABE9F"/>
+                <TextBox Name="txtUserAgent" Text="{Binding UserAgent}" Grid.Row="3" Grid.Column="1"
+                         Height="22" Width="330" HorizontalAlignment="Left" VerticalAlignment="Top"
+                         Background="Black" BorderBrush="#FF76591B" Foreground="#FFAB9066" SelectionBrush="#FFCABE9F">
+                </TextBox>
+                <TextBox Name="txtCloudFlareId" Text="{Binding CloudFlareId}" Grid.Row="4" Grid.Column="1"
+                         Height="22" Width="330" HorizontalAlignment="Left" VerticalAlignment="Top"
+                         Background="Black" BorderBrush="#FF76591B" Foreground="#FFAB9066" SelectionBrush="#FFCABE9F">
+                </TextBox>
+                <TextBox Name="txtCloudFlareClearance" Text="{Binding CloudFlareClearance}" Grid.Row="5" Grid.Column="1"
+                         Height="22" Width="330" HorizontalAlignment="Left" VerticalAlignment="Top"
+                         Background="Black" BorderBrush="#FF76591B" Foreground="#FFAB9066" SelectionBrush="#FFCABE9F">
+                </TextBox>
 
-                <Grid Grid.Row="3" Grid.Column="1">
+                <Image x:Name="cloudFlareIdQ" Margin="7,4,0,0" Source="/Procurement;component/Images/circleQuestion.png"
+                       Stretch="None" RenderTransformOrigin="3.075,0.702" Grid.Row="4" Grid.Column="2"
+                       HorizontalAlignment="Left" VerticalAlignment="Top" ToolTipService.VerticalOffset="5">
+                    <Image.ToolTip>
+                        <ToolTip Style="{StaticResource tooltipStyle}">
+                            <TextBlock Text="When using SessionID, the value of the __cfduid cookie."/>
+                        </ToolTip>
+                    </Image.ToolTip>
+                </Image>
+
+                <Image x:Name="cloudFlareClearanceQ" Margin="7,4,0,0" Source="/Procurement;component/Images/circleQuestion.png"
+                       Stretch="None" RenderTransformOrigin="3.075,0.702" Grid.Row="5" Grid.Column="2"
+                       HorizontalAlignment="Left" VerticalAlignment="Top" ToolTipService.VerticalOffset="5">
+                    <Image.ToolTip>
+                        <ToolTip Style="{StaticResource tooltipStyle}">
+                            <TextBlock Text="When using SessionID, the value of the cf_clearance cookie."/>
+                        </ToolTip>
+                    </Image.ToolTip>
+                </Image>
+
+
+                <Grid Grid.Row="6" Grid.Column="1">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="90"/>
                         <ColumnDefinition Width="90"/>
@@ -98,7 +144,7 @@
                         </Image>
                     </Grid>
                 </Grid>
-                <Grid Grid.Row="4" Grid.Column="1">
+                <Grid Grid.Row="7" Grid.Column="1">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="180"/>
                         <ColumnDefinition Width="159"/>
@@ -118,7 +164,7 @@
             </Grid>
 
             <Grid Grid.Row="1">
-                <RichTextBox Name="StatusBox" Width="641" HorizontalAlignment="Left" Margin="2,-74,0,30" Background="Black" BorderBrush="#FF93732D" Focusable="True" Foreground="#FFAB9066" FontFamily="Consolas" BorderThickness="1" IsReadOnly="True" VerticalScrollBarVisibility="Hidden" />
+                <RichTextBox Name="StatusBox" Width="641" Height="300" HorizontalAlignment="Left" Margin="2,-4,0,30" Background="Black" BorderBrush="#FF93732D" Focusable="True" Foreground="#FFAB9066" FontFamily="Consolas" BorderThickness="1" IsReadOnly="True" VerticalScrollBarVisibility="Hidden" />
             </Grid>
         </Grid>
 

--- a/Procurement/View/LoginView.xaml
+++ b/Procurement/View/LoginView.xaml
@@ -177,7 +177,7 @@
             </Grid>
 
             <Grid Grid.Row="1">
-                <RichTextBox Name="StatusBox" Width="641" Height="300" HorizontalAlignment="Left" Margin="2,-4,0,30" Background="Black" BorderBrush="#FF93732D" Focusable="True" Foreground="#FFAB9066" FontFamily="Consolas" BorderThickness="1" IsReadOnly="True" VerticalScrollBarVisibility="Hidden" />
+                <RichTextBox Name="StatusBox" Width="641" HorizontalAlignment="Left" Margin="2,-4,0,0" Background="Black" BorderBrush="#FF93732D" Focusable="True" Foreground="#FFAB9066" FontFamily="Consolas" BorderThickness="1" IsReadOnly="True" VerticalScrollBarVisibility="Hidden" />
             </Grid>
         </Grid>
 

--- a/Procurement/View/LoginView.xaml.cs
+++ b/Procurement/View/LoginView.xaml.cs
@@ -42,5 +42,23 @@ namespace Procurement.View
 
             (this.DataContext as LoginWindowViewModel).NavigateHowToSessionIDwiki();
         }
+
+        // TODO: Can we have each button's mouse down and up handlers routed to the same two functions, and those
+        // functions properly route to the correct LoginWindowViewModel function?  Also, should we have the URI for
+        // the buttons a property of the buttons themselves, so we do not need two different LoginWindowViewModel
+        // functions?
+        private void userAgentQ_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            // Since DragMove() called by MouseLeftButtonDown of MainWindow may cause System.InvalidOperationException, the notice of a mouse event is stopped here.
+            // Moreover, it is also a problem that a mouse event is blocked by DragMove() and MouseLeftButtonUp is not called.
+            e.Handled = true;
+        }
+
+        private void userAgentQ_MouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            e.Handled = true;
+
+            (this.DataContext as LoginWindowViewModel).NavigateWhatIsMyUserAgent();
+        }
     }
 }

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -31,8 +31,7 @@ namespace Procurement.ViewModel
 
         protected void OnPropertyChanged(string property)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(property));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
         }
 
         private string email;

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -416,9 +416,20 @@ namespace Procurement.ViewModel
             statusController.Ok();
         }
 
+        private void openWebPageInBrowser(string uri)
+        {
+            System.Diagnostics.Process.Start(uri);
+        }
+
         public void NavigateHowToSessionIDwiki()
         {
-            System.Diagnostics.Process.Start("https://github.com/Stickymaddness/Procurement/wiki/SessionID");
+            openWebPageInBrowser("https://github.com/Stickymaddness/Procurement/wiki/SessionID");
+        }
+
+        public void NavigateWhatIsMyUserAgent()
+        {
+            // TODO: Link to a Procurement wiki page that links to this page, once one is set up.
+            openWebPageInBrowser("https://www.whatismybrowser.com/detect/what-is-my-user-agent");
         }
     }
 }

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -24,7 +24,6 @@ namespace Procurement.ViewModel
         public delegate void LoginCompleted();
         private bool formChanged = false;
         private bool passwordChanged = false;
-        private bool useSession;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -50,6 +49,7 @@ namespace Procurement.ViewModel
             }
         }
 
+        private bool useSession;
         public bool UseSession
         {
             get { return useSession; }
@@ -77,6 +77,42 @@ namespace Procurement.ViewModel
             }
         }
 
+        private string _userAgent;
+        public string UserAgent
+        {
+            get { return _userAgent; }
+            set
+            {
+                _userAgent = value;
+                Settings.UserSettings["UserAgent"] = value;
+                OnPropertyChanged("UserAgent");
+            }
+        }
+
+        private string _cloudFlareId;
+        public string CloudFlareId
+        {
+            get { return _cloudFlareId; }
+            set
+            {
+                _cloudFlareId = value;
+                Settings.UserSettings["CloudFlareId"] = value;
+                OnPropertyChanged("CloudFlareId");
+            }
+        }
+
+        private string _cloudFlareClearance;
+        public string CloudFlareClearance
+        {
+            get { return _cloudFlareClearance; }
+            set
+            {
+                _cloudFlareClearance = value;
+                Settings.UserSettings["CloudFlareClearance"] = value;
+                OnPropertyChanged("CloudFlareClearance");
+            }
+        }
+
         private void updateButtonLabels(bool useSession)
         {
             if (this.view == null)
@@ -99,6 +135,12 @@ namespace Procurement.ViewModel
 
             if (!string.IsNullOrEmpty(Settings.UserSettings["AccountPassword"]))
                 this.view.txtPassword.Password = string.Empty.PadLeft(8); //For the visuals
+
+            UserAgent = Settings.UserSettings.ContainsKey("UserAgent") ? Settings.UserSettings["UserAgent"] : "";
+            CloudFlareId = Settings.UserSettings.ContainsKey("CloudFlareId") ?
+                Settings.UserSettings["CloudFlareId"] : "";
+            CloudFlareClearance = Settings.UserSettings.ContainsKey("CloudFlareClearance") ?
+                Settings.UserSettings["CloudFlareClearance"] : "";
 
             this.view.txtPassword.PasswordChanged += new RoutedEventHandler(txtPassword_PasswordChanged);
             PropertyChanged += loginWindow_PropertyChanged;
@@ -158,7 +200,8 @@ namespace Procurement.ViewModel
                 // behavior the user expects.
                 SecureString password = passwordChanged ? this.view.txtPassword.SecurePassword :
                     Settings.UserSettings["AccountPassword"].Decrypt();
-                ApplicationState.Model.Authenticate(Email, password, offline, useSession);
+                ApplicationState.Model.Authenticate(Email, password, offline, useSession, UserAgent, CloudFlareId,
+                    CloudFlareClearance);
 
                 if (formChanged)
                     saveSettings(password);


### PR DESCRIPTION
This is a rather janky fix so we can log in while using Session ID.  The user must provide his user agent, and the values of two cloud flare cookies, on the login window.  The first, "CloudFlare ID" (the cookie named `__cfduid`), appears to be pretty static.  However, the second, "CloudFlare PW" (the cookie named `cf_clearance`), appears to expire after about an hour, and it also appears it can not be reused after a failed login attempt.  The user must navigate to `https://www.pathofexile.com/login` in his browser to force refreshing the `cf_clearance` cookie.  I haven't tried keeping Procurement open for a while and seeing if that cookie invalidates after a while; the user might end up needing to re-log-in every so often.

I personally think the additions to the UI are awful, and would love for them to be redone by a more loving hand, but... it works.

Partially addresses #901.