### PR TITLE
Only get buyouts for items with valid IDs.

### DIFF
--- a/Procurement/Controls/ItemDisplay.xaml.cs
+++ b/Procurement/Controls/ItemDisplay.xaml.cs
@@ -85,7 +85,7 @@ namespace Procurement.Controls
 
                 string pricingInfo = string.Empty;
 
-                if (Settings.Buyouts.ContainsKey(item.Id))
+                if (!string.IsNullOrWhiteSpace(item.Id) && Settings.Buyouts.ContainsKey(item.Id))
                 {
                     pricingInfo = Settings.Buyouts[item.Id].Buyout;
 


### PR DESCRIPTION
For some "invalid" items, such as the example item JSON GGG provides to demonstrate new API features, items might not have an ID set.  This causes an exception when trying to look up the item's buyout.  Check for this case and skip looking up a buyout value.