### PR TITLE
Add support for veiled mods.

### DIFF
--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -53,6 +53,7 @@ namespace POEApi.Model
         public List<string> FlavourText { get; set; }
 
         public List<string> CraftedMods { get; set; }
+        public List<string> VeiledMods { get; set; }
 
         public int TradeX { get; set; }
         public int TradeY { get; set; }
@@ -83,8 +84,9 @@ namespace POEApi.Model
             this.SecDescrText = item.SecDescrText;
             this.Explicitmods = item.ExplicitMods;
             this.ItemType = Model.ItemType.UnSet;
-            this.CraftedMods = item.CraftedMods;
-            this.EnchantMods = item.EnchantMods;
+            this.CraftedMods = item.CraftedMods ?? new List<string>();
+            this.VeiledMods = item.VeiledMods ?? new List<string>();
+            this.EnchantMods = item.EnchantMods ?? new List<string>();
             this.FlavourText = item.FlavourText;
             this.ItemLevel = item.Ilvl;
             this.Shaper = item.Shaper;

--- a/POEApi.Model/JSONProxy/Stash.cs
+++ b/POEApi.Model/JSONProxy/Stash.cs
@@ -66,6 +66,7 @@ namespace POEApi.Model.JSONProxy
         public List<string> CosmeticMods { get; set; }
         public List<string> CraftedMods { get; set; }
         public List<string> EnchantMods { get; set; }
+        public List<string> VeiledMods { get; set; }
         public int Ilvl { get; set; }
         public string ProphecyText { get; set; }
         public string ProphecyDiffText { get; set; }

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -274,6 +274,29 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
+                    <ItemsControl ItemsSource="{Binding VeiledMods}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding HasVeiledMods,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="#b4b4ff"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
                     <!-- The pseudo-explicit property "Mirrored" should appear after any real explicit mods and any
                          crafted mods.  It is mutually exclusive with being corrupted. -->
                     <!-- TODO: Padding bug: there is extra padding between explicit mods, crafted mods, and the

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -191,6 +191,7 @@
     <Compile Include="ViewModel\Filters\ForumExport\MapFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\MirroredItemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\MovementSpeed.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\MultipleVeiledModsFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\PercentEnergyShieldFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\PercentLifeFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\ProphecyFilter.cs" />
@@ -202,6 +203,9 @@
     <Compile Include="ViewModel\Filters\ForumExport\SocketColourFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\UnknownItemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\ScarabFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\VeiledModFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\VeiledPrefixFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\VeiledSuffixFilter.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\CurrencyVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\DivineVesselVisitor.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\ElderItemVisitor.cs" />

--- a/Procurement/ViewModel/Filters/ForumExport/MultipleVeiledModsFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/MultipleVeiledModsFilter.cs
@@ -1,0 +1,32 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class MultipleVeiledModsFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get { return false; }
+        }
+
+        public string Keyword
+        {
+            get { return "Multiple Veiled Mods"; }
+        }
+
+        public string Help
+        {
+            get { return "Items with more than one veiled mod"; }
+        }
+
+        public FilterGroup Group
+        {
+            get { return FilterGroup.Default; }
+        }
+
+        public bool Applicable(Item item)
+        {
+            return item.VeiledMods?.Count > 1;
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/VeiledModFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/VeiledModFilter.cs
@@ -1,0 +1,32 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class VeiledModFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get { return false; }
+        }
+
+        public string Keyword
+        {
+            get { return "Veiled Mods"; }
+        }
+
+        public string Help
+        {
+            get { return "Items with veiled mods"; }
+        }
+
+        public FilterGroup Group
+        {
+            get { return FilterGroup.Default; }
+        }
+
+        public bool Applicable(Item item)
+        {
+            return item.VeiledMods?.Count > 0;
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/VeiledPrefixFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/VeiledPrefixFilter.cs
@@ -1,0 +1,36 @@
+﻿using POEApi.Model;
+using System.Linq;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class VeiledPrefixFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get { return false; }
+        }
+
+        public string Keyword
+        {
+            get { return "Veiled Prefixes"; }
+        }
+
+        public string Help
+        {
+            get { return "Items with veiled prefixes"; }
+        }
+
+        public FilterGroup Group
+        {
+            get { return FilterGroup.Default; }
+        }
+
+        public bool Applicable(Item item)
+        {
+            if (item.VeiledMods == null)
+                return false;
+
+            return item.VeiledMods.Count > 0 && item.VeiledMods.Any(x => x.StartsWith("Prefix"));
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/VeiledSuffixFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/VeiledSuffixFilter.cs
@@ -1,0 +1,36 @@
+﻿using POEApi.Model;
+using System.Linq;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class VeiledSuffixFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get { return false; }
+        }
+
+        public string Keyword
+        {
+            get { return "Veiled Suffixes"; }
+        }
+
+        public string Help
+        {
+            get { return "Items with veiled suffixes"; }
+        }
+
+        public FilterGroup Group
+        {
+            get { return FilterGroup.Default; }
+        }
+
+        public bool Applicable(Item item)
+        {
+            if (item.VeiledMods == null)
+                return false;
+
+            return item.VeiledMods.Count > 0 && item.VeiledMods.Any(x => x.StartsWith("Suffix"));
+        }
+    }
+}

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -33,8 +33,10 @@ namespace Procurement.ViewModel
         public string FlavourText { get; private set; }
 
         public List<string> CraftedMods { get; set; }
+        public List<string> VeiledMods { get; set; }
 
         public bool HasCraftedMods { get; private set; }
+        public bool HasVeiledMods { get; private set; }
         public bool IsProphecy { get; set; }
         public string ProphecyText { get; set; }
         public string ProphecyDifficultyText { get; set; }
@@ -67,6 +69,7 @@ namespace Procurement.ViewModel
             this.EnchantMods = item.EnchantMods;
 
             this.CraftedMods = item.CraftedMods;
+            setVeiledMods(item);
 
             SecondaryDescriptionText = item.SecDescrText;
             setTypeSpecificProperties(item);
@@ -74,7 +77,8 @@ namespace Procurement.ViewModel
             // If an item has crafted mods but no true explicit mods:
             //   In game: the crafted mods are correctly separated from the previous section.
             //   On official web site: there is no seperator added before the previous section.
-            this.HasCraftedMods = CraftedMods != null && CraftedMods.Count > 0;
+            this.HasCraftedMods = CraftedMods?.Count > 0;
+            this.HasVeiledMods = VeiledMods?.Count > 0;
             this.HasExplicitMods = ExplicitMods?.Count > 0 || HasCraftedMods || IsMirrored;
             this.HasImplicitMods = ImplicitMods?.Count > 0;
             this.HasEnchantMods = item.EnchantMods.Count > 0;
@@ -86,6 +90,27 @@ namespace Procurement.ViewModel
             }
 
             setProphecyProperties(item);
+        }
+
+        private void setVeiledMods(Item item)
+        {
+            // The text for veiled mods is in the format "(Prefix|Suffix)##" where ## currently can be 01-06.
+            VeiledMods = new List<string>();
+            foreach (var veiledMod in item.VeiledMods)
+            {
+                if (veiledMod.StartsWith("Prefix"))
+                {
+                    VeiledMods.Add("Veiled Prefix");
+                }
+                else if (veiledMod.StartsWith("Suffix"))
+                {
+                    VeiledMods.Add("Veiled Suffix");
+                }
+                else
+                {
+                    VeiledMods.Add("Veiled Affix");
+                }
+            }
         }
 
         private void setProphecyProperties(Item item)


### PR DESCRIPTION
This PR adds veiled mods as a property of `Item` objects, alongside crafted mods (since veiled mods become crafted mods after being unveiled), and displays a simple text string in the item hover.  We can change the text string later to be similar to the animation that is currently shown in game, but for now there is some indication that veiled mods are present.