### PR TITLE
Allow highlights to apply across all stash tab types

### DIFF
--- a/Procurement/Controls/StashTabControl.xaml.cs
+++ b/Procurement/Controls/StashTabControl.xaml.cs
@@ -20,6 +20,10 @@ namespace Procurement.Controls
         {
             InitializeComponent();
 
+            Refresh();
+
+            Ready = true;
+
             SetPremiumTabBorderColour();
         }
 

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -227,6 +227,7 @@
     <Compile Include="ViewModel\Recipes\MatchedSet.cs" />
     <Compile Include="ViewModel\SetTabBuyoutViewModel.cs" />
     <Compile Include="ViewModel\TabViewModel\CommonTabViewModel.cs" />
+    <Compile Include="ViewModel\TabViewModel\TabFactory.cs" />
     <Compile Include="ViewModel\TradeSettingsViewModel.cs" />
     <Compile Include="ViewModel\Cache\BitmapCache.cs" />
     <Compile Include="ViewModel\DisplayModeStrategy\DisplayModeFactory.cs" />

--- a/Procurement/View/Converters/TabIDToStashControlConverter.cs
+++ b/Procurement/View/Converters/TabIDToStashControlConverter.cs
@@ -47,12 +47,11 @@ namespace Procurement.View
             int inventoryId = int.Parse(item.InventoryId.Replace("Stash", "")) - 1;
             Grid g = new Grid();
 
-            StashTabControl tabControl = new StashTabControl(inventoryId);
             Tab tab = ApplicationState.Stash[ApplicationState.CurrentLeague].Tabs.Find(t => t.i == inventoryId);
+            var tabControl = TabFactory.GenerateTab(tab, new List<IFilter>() {new ItemFilter(item)});
             Image tabImage = getImage(tab, true);
 
-            tabControl.SetValue(StashTabControl.FiltersProperty, new List<IFilter>() { new ItemFilter(item) });
-            tabControl.ForceUpdate();
+
             RowDefinition imageRow = new RowDefinition();
             imageRow.Height = new GridLength(26);
             g.RowDefinitions.Add(imageRow);
@@ -63,6 +62,7 @@ namespace Procurement.View
             g.Children.Add(tabControl);
             cache.Add(key, g);
 
+            tabControl.ForceUpdate();
             return g;
         }
 

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -291,23 +291,7 @@ namespace Procurement.ViewModel
                     BorderBrush = Brushes.Transparent
                 };
 
-                AbstractStashTabControl stashTab;
-
-                switch (currentTab.Type)
-                {
-                    case TabType.Currency:
-                        stashTab = new CurrencyStashTab(currentTab.i, getUserFilter(string.Empty));
-                        break;
-                    case TabType.Essence:
-                        stashTab = new EssenceStashTab(currentTab.i, getUserFilter(string.Empty));
-                        break;
-                    case TabType.Fragment:
-                        stashTab = new FragmentStashTab(currentTab.i, getUserFilter(string.Empty));
-                        break;
-                    default:
-                        stashTab = new StashTabControl(currentTab.i, getUserFilter(string.Empty));
-                        break;
-                }
+                var stashTab = TabFactory.GenerateTab(currentTab, getUserFilter(string.Empty));
 
                 CraftTabAndContent(item, stashTab, i);
 

--- a/Procurement/ViewModel/TabViewModel/TabFactory.cs
+++ b/Procurement/ViewModel/TabViewModel/TabFactory.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using POEApi.Model;
+using Procurement.Controls;
+using Procurement.ViewModel.Filters;
+
+namespace Procurement.ViewModel
+{
+    public static class TabFactory
+    {
+        public static AbstractStashTabControl GenerateTab(Tab tab, List<IFilter> filters)
+        {
+            AbstractStashTabControl stashTab;
+
+            switch (tab.Type)
+            {
+                case TabType.Currency:
+                    stashTab = new CurrencyStashTab(tab.i, filters);
+                    break;
+                case TabType.Essence:
+                    stashTab = new EssenceStashTab(tab.i, filters);
+                    break;
+                case TabType.Fragment:
+                    stashTab = new FragmentStashTab(tab.i, filters);
+                    break;
+                default:
+                    stashTab = new StashTabControl(tab.i, filters);
+                    break;
+            }
+
+            return stashTab;
+        }
+    }
+}


### PR DESCRIPTION
I saw that recipes no longer highlight while working on the vaal orb recipe after the #915 

This is kind of a key feature of procurement!

I've remedied this and allowed the filter to apply to any type of stash tab.



