### PR TITLE
Memory management

### DIFF
--- a/Procurement/MainWindow.xaml
+++ b/Procurement/MainWindow.xaml
@@ -2,7 +2,11 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:v="clr-namespace:Procurement.View"
-        Height="1000" Width="1100" Background="Transparent" AllowsTransparency="True" WindowStyle="None" ResizeMode="NoResize" WindowStartupLocation="CenterScreen" Icon="/Procurement;component/Images/Procurement.ico" UseLayoutRounding="True">
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:viewModel="clr-namespace:Procurement.ViewModel"
+        mc:Ignorable="d"
+        Height="1000" Width="1100" Background="Transparent" AllowsTransparency="True" WindowStyle="None" ResizeMode="NoResize" WindowStartupLocation="CenterScreen" Icon="/Procurement;component/Images/Procurement.ico" UseLayoutRounding="True"
+        d:DataContext="{d:DesignInstance viewModel:ScreenController }">
     <Window.Resources>
         <v:VisibilityConverter x:Key="vc" />
     </Window.Resources>
@@ -17,7 +21,7 @@
         <Grid x:Name="Header" Margin="1,0,-1,0" Visibility="{Binding FullMode, Converter={StaticResource vc}}">
             <Grid.Background>
                 <ImageBrush ImageSource="/Procurement;component/Images/header.png"/>
-            </Grid.Background>            
+            </Grid.Background>
         </Grid>
 
         <Grid Grid.Row="1" x:Name="MainGrid">
@@ -28,14 +32,14 @@
                 <RowDefinition Height="58"/>
                 <RowDefinition />
             </Grid.RowDefinitions>
-            
-            
+
+
             <Grid  Grid.Row="0" VerticalAlignment="Top">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="880"/>
                     <ColumnDefinition Width="273"/>
                 </Grid.ColumnDefinitions>
-                <Grid Grid.Column="0" x:Name="Buttons" Visibility="Hidden">
+                <Grid Grid.Column="0" Visibility="{Binding ButtonsVisible, Converter={StaticResource bc}}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="108"/>
                         <ColumnDefinition Width="128"/>
@@ -171,10 +175,8 @@
                 </Grid>
             </Grid>
 
-            <Grid x:Name="MainRegion" Grid.Row="1">
-                
-            </Grid>
-            
+            <ContentPresenter Grid.Row="1" Content="{Binding SelectedView}" />
+
         </Grid>
 
         <Grid x:Name="Footer" Grid.Row="2" Margin="7,0,-7,0" Visibility="{Binding FullMode, Converter={StaticResource vc}}">
@@ -182,6 +184,6 @@
                 <ImageBrush ImageSource="/Procurement;component/Images/footer.png"/>
             </Grid.Background>
         </Grid>
-        
+
     </Grid>
 </Window>

--- a/Procurement/MainWindow.xaml.cs
+++ b/Procurement/MainWindow.xaml.cs
@@ -18,8 +18,10 @@ namespace Procurement
         {
             InitializeComponent();
             this.Title = ApplicationState.Version;
-            ScreenController.Create(this);
-            this.DataContext = ScreenController.Instance;
+            ScreenController.Create();
+
+            DataContext = ScreenController.Instance;
+
             this.MouseLeftButtonDown += new MouseButtonEventHandler(MainWindow_MouseLeftButtonDown);
 
             Loaded += (o, e) =>


### PR DESCRIPTION
As I was clicking between the stash view and the recipe view I noticed that it was a smidge slow displaying the stash. When I looked at the resource manager I also noticed that the memory held by procurement was spiking pretty hard.

I dug through the main window code and saw that there was a lack of binding and quite a bit of "Extra" work being done that isn't needed.

The stash view is now being regenerated only on a refresh and we use data bindings to show the view that we want. There is something in the "StashVIew" that isn't releasing cleanly so persistent refreshes will still cause the memory to climb but this PR irons out some of the issue.