### PR TITLE
Fix imprint itemhover crash

### DIFF
--- a/POEApi.Model/Property.cs
+++ b/POEApi.Model/Property.cs
@@ -12,16 +12,23 @@ namespace POEApi.Model
 
         internal Property(JSONProxy.Property property)
         {
-            this.Name = property.Name;
+            Name = property.Name;
             Values = new List<Tuple<string, int>>();
 
             foreach (object value in property.Values)
             {
-                var pair = (JArray) value;
-                Values.Add(new Tuple<string, int>(pair[0].ToString(), int.Parse(pair[1].ToString())));
+                var pair = (JArray)value;
+                Values.Add(new Tuple<string, int>(Sanitize(pair[0]), int.Parse(pair[1].ToString())));
             }
-            
-            this.DisplayMode = property.DisplayMode;
+
+            DisplayMode = property.DisplayMode;
+        }
+
+        private string Sanitize(JToken jToken)
+        {
+            const string infoText = "<<set:MS>><<set:M>><<set:S>>";
+
+            return jToken.ToString().Replace(infoText, string.Empty);
         }
     }
 }

--- a/Procurement/ViewModel/DisplayModeStrategy/DisplayModeStrategyBase.cs
+++ b/Procurement/ViewModel/DisplayModeStrategy/DisplayModeStrategyBase.cs
@@ -19,8 +19,8 @@ namespace Procurement.ViewModel
             displayColorMappings.Add(5, new SolidColorBrush((Color)ColorConverter.ConvertFromString("#2943c6"))); //Blue cold
             displayColorMappings.Add(6, new SolidColorBrush((Color)ColorConverter.ConvertFromString("#f2bc01"))); //Yellow lightning
             displayColorMappings.Add(7, new SolidColorBrush((Color)ColorConverter.ConvertFromString("#D02090"))); //Pink chaos
+            displayColorMappings.Add(8, new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFFFFF"))); //Imprint White
             displayColorMappings.Add(9, new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFFFFF"))); //White
-            
         }
 
         public abstract Block Get();


### PR DESCRIPTION
I remember running into items with the "<<set:MS>><<set:M>><<set:S>>" text in the past, from what I remember we used a quick and dirty string replace initially, but found a cleaner fix which I can't seem to find. 

Any ideas @aydjay @thailyn ?