### PR TITLE
Fix max level gems experience bug

### DIFF
--- a/POEApi.Model/Gem.cs
+++ b/POEApi.Model/Gem.cs
@@ -34,7 +34,7 @@ namespace POEApi.Model
 
         private void ExtractGemExperience(JSONProxy.Item item)
         {
-            var experienceProperties = item.AdditionalProperties.FirstOrDefault(x => x.Name == "Experience");
+            var experienceProperties = item.AdditionalProperties?.FirstOrDefault(x => x.Name == "Experience");
 
             if (experienceProperties == null)
             {
@@ -61,6 +61,8 @@ namespace POEApi.Model
             {
                 ExperienceDenominator = temporaryInt;
             }
+
+            HasExperience = true;
         }
 
         private int getLevel()
@@ -74,5 +76,7 @@ namespace POEApi.Model
             
             return level;
         }
+
+        public bool HasExperience { get; set; }
     }
 }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -44,7 +44,18 @@ namespace Procurement.ViewModel
 
         public string ItemLevel { get; set; }
 
-        public bool IsGemProgressVisible => Item is Gem;
+        public bool IsGemProgressVisible
+        {
+            get
+            {
+                var gem = Item as Gem;
+
+                if (gem == null)
+                    return false;
+
+                return gem.HasExperience;
+            }
+        }
 
         public double LevelExperienceProgress { get; set; }
 


### PR DESCRIPTION
Experience detection code was bombing due to lack of additional properties.

https://github.com/Stickymaddness/Procurement/blob/b19241d8d3c91f8fd0b11f225fa1e98382b17b17/POEApi.Model/Gem.cs#L37

I've null checked this and done as the POE website has done and "Hidden" the gem progress bar.

Fixes #959 