### PR TITLE
Fix item search for certain system locales

### DIFF
--- a/Procurement/ViewModel/Filters/ForumExport/AttackSpeed.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/AttackSpeed.cs
@@ -8,7 +8,7 @@
         }
 
         public AttackSpeed()
-            : base("Increased Attack Speed", "Increased Attack Speed", "Increased Attack Speed")
+            : base("Increased Attack Speed", "Increased Attack Speed", "increased Attack Speed")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/CastSpeed.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/CastSpeed.cs
@@ -8,7 +8,7 @@
         }
 
         public CastSpeed()
-            : base("Increased Cast Speed", "Increased Cast Speed", "Increased Cast Speed")
+            : base("Increased Cast Speed", "Increased Cast Speed", "increased Cast Speed")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/IncreasedDamageFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/IncreasedDamageFilter.cs
@@ -15,21 +15,21 @@
     internal class IncreasedDamageFilterCold : IncreasedDamageFilter
     {
         public IncreasedDamageFilterCold()
-            : base("Increased Cold Damage", "Increased Cold Damage", "Increased Cold Damage")
+            : base("Increased Cold Damage", "Increased Cold Damage", "increased Cold Damage")
         { }
     }
 
     internal class IncreasedDamageFilterFire : IncreasedDamageFilter
     {
         public IncreasedDamageFilterFire()
-            : base("Increased Fire Damage", "Increased Fire Damage", "Increased Fire Damage")
+            : base("Increased Fire Damage", "Increased Fire Damage", "increased Fire Damage")
         { }
     }
 
     internal class IncreasedDamageFilterLightning : IncreasedDamageFilter
     {
         public IncreasedDamageFilterLightning()
-            : base("Increased Lightning Damage", "Increased Lightning Damage", "Increased Lightning Damage")
+            : base("Increased Lightning Damage", "Increased Lightning Damage", "increased Lightning Damage")
         { }
     }
 

--- a/Procurement/ViewModel/Filters/ForumExport/ItemQuantityFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ItemQuantityFilter.cs
@@ -13,7 +13,7 @@ namespace Procurement.ViewModel.Filters
         }
 
         public ItemQuantityFilter()
-            : base("Item Quantity", "Item with the Item Quantity stat", "INCREASED QUANTITY")
+            : base("Item Quantity", "Item with the Item Quantity stat", "increased Quantity")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/ItemRarityFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ItemRarityFilter.cs
@@ -8,7 +8,7 @@
         }
 
         public ItemRarityFilter()
-            : base("Item Rarity", "Item with the Item Rarity stat", "INCREASED RARITY")
+            : base("Item Rarity", "Item with the Item Rarity stat", "increased Rarity")
         { }
     }
 }


### PR DESCRIPTION
As mentioned in #949 using upper case "I" is causing issues on some system locales, this should fix it. Uses same lower case "i" as it is used on items.