### PR TITLE
Update CloudFlareUtilities library to 1.3.0.

### DIFF
--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CloudFlareUtilities, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CloudFlareUtilities.1.2.0\lib\netstandard1.1\CloudFlareUtilities.dll</HintPath>
+    <Reference Include="CloudFlareUtilities, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CloudFlareUtilities.1.3.0\lib\netstandard1.1\CloudFlareUtilities.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CloudFlareUtilities" version="1.2.0" targetFramework="net45" />
+  <package id="CloudFlareUtilities" version="1.3.0" targetFramework="net45" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />


### PR DESCRIPTION
This version of the library adds support for addition types of CloudFlare authentication, so logging in to Procurement should be much, much less troublesome now.

Fixes #1002.