### PR TITLE
Revert "Item Background generation refactor"

### DIFF
--- a/Procurement/App.xaml
+++ b/Procurement/App.xaml
@@ -10,7 +10,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Procurement;component/Controls/TabControlStyle.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <ResourceDictionary x:Key="ExpressionDarkGrid" Source="Controls/ExpressionDarkGrid.xaml" />
+
             <view:VisibilityConverter x:Key="bc" />
             <view:ItemToItemHoverSymbolVisibility x:Key="symbolVisibility" />
             <view:ItemToItemHoverSymbolPath x:Key="symbolPath" />

--- a/Procurement/Controls/AbstractStashTabControl.cs
+++ b/Procurement/Controls/AbstractStashTabControl.cs
@@ -104,6 +104,38 @@ namespace Procurement.Controls
             Refresh();
         }
 
+        protected void SetBackground(Grid childGrid, Item item)
+        {
+            var gear = item as Gear;
+
+            if (gear == null)
+                return;
+
+            if (gear.Rarity != Rarity.Normal && gear.Explicitmods == null)
+                childGrid.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#88001D"));
+            else
+                childGrid.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#21007F"));
+
+            childGrid.Background.Opacity = 0.3;
+
+            SetItemBackground(childGrid, item);
+        }
+
+        private static void SetItemBackground(Grid childGrid, Item item)
+        {
+            if (!item.HasBackground)
+                return;
+
+            try
+            {
+                (childGrid.Children[0] as ItemDisplay).Background = new ImageBrush(ApplicationState.BitmapCache[item.BackgroundUrl]);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(ex);
+            }
+        }
+
         private void UpdateStashByLocation()
         {
             TabItemsToViewModels.Clear();

--- a/Procurement/Controls/ForumTemplate.xaml
+++ b/Procurement/Controls/ForumTemplate.xaml
@@ -7,7 +7,6 @@
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300" Background="Black">
     <UserControl.Resources>
-        <!--Todo: Look at removing this, it is declared in the app.xaml, we don't need it here too.-->
         <ResourceDictionary Source="ExpressionDarkGrid.xaml" />
     </UserControl.Resources>
     <Border Grid.Column="0" BorderBrush="#FF76591B" BorderThickness="2" Background="Black">

--- a/Procurement/Controls/Inventory.xaml.cs
+++ b/Procurement/Controls/Inventory.xaml.cs
@@ -99,6 +99,8 @@ namespace Procurement.Controls
 
                     Item gearAtLocation = inventByLocation[currentKey];
 
+                    setBackround(childGrid, gearAtLocation);
+
                     Border border = getBorder();
                     childGrid.Children.Add(border);
 
@@ -130,6 +132,16 @@ namespace Procurement.Controls
             b.BorderBrush = Brushes.Transparent;
             b.BorderThickness = new Thickness(1);
             return b;
+        }
+
+        private void setBackround(Grid childGrid, Item item)
+        {
+            if (item is Gear && (item as Gear).Rarity != Rarity.Normal && (item as Gear).Explicitmods == null)
+                childGrid.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#88001D"));
+            else
+                childGrid.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#21007F"));
+
+            childGrid.Background.Opacity = 0.3;
         }
 
         private bool search(Item item)

--- a/Procurement/Controls/ItemDisplay.xaml
+++ b/Procurement/Controls/ItemDisplay.xaml
@@ -8,28 +8,12 @@
              d:DesignHeight="300" d:DesignWidth="300" Loaded="ItemDisplay_Loaded" MouseRightButtonUp="ItemDisplay_MouseRightButtonUp"
              d:DataContext="{d:DesignInstance viewModel:ItemDisplayViewModel}">
     <UserControl.Resources>
-        <SolidColorBrush x:Key="UnidBrush" Color="#88001D" />
-        <SolidColorBrush x:Key="IdBrush" Color="#21007F"/>
-        <Style x:Key="OpaqueBackgroundStyle" TargetType="Grid" >
-            <Setter Property="Background" Value="{StaticResource IdBrush}" />
-            <Setter Property="Opacity" Value="0.3" />
-            <Style.Triggers> 
-                <DataTrigger Binding="{Binding IsItemIdentified}" Value="False">
-                    <Setter Property="Background" Value="{StaticResource UnidBrush}" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding IsItemIdentified}" Value="{x:Null}">
-                    <Setter Property="Background" Value="Transparent" />
-                </DataTrigger>
-            </Style.Triggers>
-        </Style>
-
+        <ResourceDictionary x:Key="ExpressionDarkGrid" Source="ExpressionDarkGrid.xaml" />
     </UserControl.Resources>
     <Grid>
-        <Border BorderBrush="{Binding ItemFilterBrush}" BorderThickness="2">
+        <Border BorderBrush="{Binding ItemFilterBrush}" BorderThickness="2" >
             <Grid x:Name="MainGrid" Margin="-2">
-                <Image Source="{Binding ItemImage}" />
-                <Grid Style="{StaticResource OpaqueBackgroundStyle}" />
-                <Grid Visibility="{Binding HasSpecialBackground}" Background="{Binding SpecialBackground}" />
+
             </Grid>
         </Border>
 
@@ -43,6 +27,7 @@
                    Visibility="{Binding IsStackSizeVisible,
                                Converter={StaticResource bc},
                                ConverterParameter=CollapseWhenFalse}" />
-        </Grid>
+    </Grid>
+    
     
 </UserControl>

--- a/Procurement/Controls/ItemDisplay.xaml.cs
+++ b/Procurement/Controls/ItemDisplay.xaml.cs
@@ -84,7 +84,7 @@ namespace Procurement.Controls
             var vm = DataContext as ItemDisplayViewModel;
             if (vm != null)
             {
-                var i = vm.ItemImage;
+                var i = vm.getImage();
                 itemImage = i;
 
                 if (vm.Item != null && vm.Item.IsGear && itemImage != null)
@@ -224,7 +224,7 @@ namespace Procurement.Controls
             var menu = new ContextMenu();
             menu.Background = Brushes.Black;
 
-            menu.Resources = Application.Current.Resources["ExpressionDarkGrid"] as ResourceDictionary;
+            menu.Resources = Resources["ExpressionDarkGrid"] as ResourceDictionary;
 
             var setBuyout = new MenuItem();
             setBuyout.StaysOpenOnClick = true;

--- a/Procurement/Controls/StashTabControl.xaml.cs
+++ b/Procurement/Controls/StashTabControl.xaml.cs
@@ -105,6 +105,8 @@ namespace Procurement.Controls
 
                     childGrid.Children.Add(itemDisplay);
 
+                    SetBackground(childGrid, keyItem);
+                    
                     Grid.SetColumn(childGrid, i);
                     Grid.SetRow(childGrid, j);
                     if (itemViewModel.Item.H > 1)

--- a/Procurement/ViewModel/ItemDisplayViewModel.cs
+++ b/Procurement/ViewModel/ItemDisplayViewModel.cs
@@ -12,6 +12,14 @@ using Procurement.Utility;
 
 namespace Procurement.ViewModel
 {
+    public class LinkPath
+    {
+        public Image image;
+        public int row { get; set; }
+        public int col { get; set; }
+    }
+
+
     public class ItemDisplayViewModel : ObservableBase
     {
         private bool isQuadStash;
@@ -30,8 +38,6 @@ namespace Procurement.ViewModel
                 return gear != null && gear.Sockets.Count > 0;
             }
         }
-
-        public bool? IsItemIdentified => Item?.Identified;
 
         public bool IsItemInFilter
         {
@@ -71,29 +77,10 @@ namespace Procurement.ViewModel
             this.Item = item;
         }
 
-        public bool HasSpecialBackground => Item != null && Item.HasBackground;
-
-        public ImageBrush SpecialBackground
+        public Image getImage()
         {
-            get
+            if (Item != null)
             {
-                if (HasSpecialBackground == false)
-                    return null;
-
-                return new ImageBrush(ApplicationState.BitmapCache[Item.BackgroundUrl]);
-            }
-
-        }
-
-        public Image ItemImage
-        {
-            get
-            {
-                if (Item == null)
-                {
-                    return null;
-                }
-
                 try
                 {
 
@@ -116,6 +103,7 @@ namespace Procurement.ViewModel
                 }
             }
 
+            return null;
         }
 
         public UIElement GetSocket(bool isQuadStash)


### PR DESCRIPTION
Reverts Stickymaddness/Procurement#989

@aydjay Unfortunately I'm going to have to revert this, as it (visually) breaks the currency tab, as the existing item slot border backgrounds weren't removed which means orbs have double backgrounds and the crafting slot item has two shades of background. In addition because the essence tab items aren't properly aligned it's much more noticeable with the backgrounds.