### PR TITLE
Add support for unique stash tabs.

### DIFF
--- a/POEApi.Model/ProxyMapper.cs
+++ b/POEApi.Model/ProxyMapper.cs
@@ -219,6 +219,7 @@ namespace POEApi.Model
             {"QuadStash", TabType.Quad},
             {"MapStash", TabType.Map },
             {"FragmentStash", TabType.Fragment },
+            {"UniqueStash", TabType.Unique },
         };
 
         public static TabType GetTabType(string type)

--- a/POEApi.Model/Tab.cs
+++ b/POEApi.Model/Tab.cs
@@ -12,6 +12,7 @@ namespace POEApi.Model
         Quad,
         Map,
         Fragment,
+        Unique,
 
         Unknown
     }


### PR DESCRIPTION
Like with map stash tabs, the items in unique stash tabs are not available from the API, so simply use a normal stash tab.