### PR TITLE
Show correct tab control when hovering tab in trading

### DIFF
--- a/Procurement/View/Converters/TabIDToStashControlConverter.cs
+++ b/Procurement/View/Converters/TabIDToStashControlConverter.cs
@@ -17,7 +17,9 @@ namespace Procurement.View
         {
             TabInfo item = value as TabInfo;
             Grid g = new Grid();
-            g.Children.Add(new StashTabControl(item.ID));
+            Tab tab = ApplicationState.Stash[ApplicationState.CurrentLeague].Tabs.Find(t => t.i == item.ID);
+            var tabControl = TabFactory.GenerateTab(tab, new List<IFilter>());
+            g.Children.Add(tabControl);
             return g;
         }
 


### PR DESCRIPTION
If there are premium tabs, the tab hover was only showing the default stash tab rather than the full stash

![2019-06-10_14-43-04](https://user-images.githubusercontent.com/9460838/59250750-0e673e00-8c20-11e9-8c45-926f58420d17.gif)

