### PR TITLE
Restore ITransport GetStash with forceRefresh.

### DIFF
--- a/POEApi.Model/POEModel.cs
+++ b/POEApi.Model/POEModel.cs
@@ -144,7 +144,7 @@ namespace POEApi.Model
 
             onStashLoaded(POEEventState.BeforeEvent, index, -1);
 
-            using (var stream = Transport.GetStash(index, league, accountName, realm))
+            using (var stream = Transport.GetStash(index, league, accountName, realm, forceRefresh))
             {
                 try
                 {

--- a/POEApi.Transport/CachedTransport.cs
+++ b/POEApi.Transport/CachedTransport.cs
@@ -42,10 +42,11 @@ namespace POEApi.Transport
             return _innerTranport.GetAccountName(realm);
         }
 
-        public Stream GetStash(int index, string league, string accountName, bool refresh, string realm)
+        public Stream GetStash(int index, string league, string accountName, string realm, bool refresh)
         {
             string key = string.Format("{0}-{1}-{2}", league, _stashKey, index);
 
+            // TODO(20190612): Don't actually clear the cache until we successfully fetch a replacement.
             if (refresh && _userCacheService.Exists(key))
                 _userCacheService.Remove(key);
 
@@ -60,7 +61,7 @@ namespace POEApi.Transport
 
         public Stream GetStash(int index, string league, string accountName, string realm)
         {
-            return GetStash(index, league, accountName, false, realm);
+            return GetStash(index, league, accountName, realm, false);
         }
 
         public Stream GetImage(string url)

--- a/POEApi.Transport/HttpTransport.cs
+++ b/POEApi.Transport/HttpTransport.cs
@@ -213,10 +213,16 @@ namespace POEApi.Transport
             }
         }
 
-        public Stream GetStash(int index, string league, string accountName, string realm )
+        // The refresh parameter in this ITransport implementation is ignored.
+        public Stream GetStash(int index, string league, string accountName, string realm, bool refresh)
         {
             var url = string.Format(StashURL, league, index, accountName, realm);
             return PerformHttpRequest(HttpMethod.GET, url);
+        }
+
+        public Stream GetStash(int index, string league, string accountName, string realm)
+        {
+            return GetStash(index, league, accountName, realm, false);
         }
 
         public Stream GetCharacters(string realm )

--- a/POEApi.Transport/ITransport.cs
+++ b/POEApi.Transport/ITransport.cs
@@ -9,6 +9,7 @@ namespace POEApi.Transport
         bool Authenticate(string email, SecureString password);
         Stream GetAccountName(string realm);
         Stream GetStash(int index, string league, string accountName, string realm);
+        Stream GetStash(int index, string league, string accountName, string realm, bool refresh);
         Stream GetImage(string url);
         Stream GetCharacters(string realm);
         Stream GetInventory(string characterName, bool forceRefresh, string accountName, string realm);

--- a/Tests/POEApi.Model.Tests/IFilterTests.cs
+++ b/Tests/POEApi.Model.Tests/IFilterTests.cs
@@ -32,7 +32,7 @@ namespace POEApi.Model.Tests
 
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -55,7 +55,7 @@ namespace POEApi.Model.Tests
 
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -77,7 +77,7 @@ namespace POEApi.Model.Tests
 
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -99,7 +99,7 @@ namespace POEApi.Model.Tests
 
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -125,7 +125,7 @@ namespace POEApi.Model.Tests
 
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", "")).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", "", false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", "");
 

--- a/Tests/POEApi.Model.Tests/PoeModelTests.cs
+++ b/Tests/POEApi.Model.Tests/PoeModelTests.cs
@@ -81,7 +81,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStash);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -97,7 +97,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithEssences);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -117,7 +117,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithRelic);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -137,7 +137,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithLitheBlade);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -157,7 +157,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithSaintlyChainmail);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -192,7 +192,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleCurrencyTabWithShards);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -214,7 +214,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleFragmentStash);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -250,7 +250,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithLeagueStoneChargeInfo);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 
@@ -298,7 +298,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithNets);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, string.Empty, string.Empty, Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, string.Empty, string.Empty, Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, string.Empty, string.Empty, Realm.PC);
                 stash.Should().NotBeNull();
@@ -336,7 +336,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithMirroredItems);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, string.Empty, string.Empty, Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, string.Empty, string.Empty, Realm.PC, false)).Returns(stream);
                 var stash = _model.GetStash(0, string.Empty, string.Empty, Realm.PC);
                 stash.Should().NotBeNull();
                 stash.Tabs.Should().HaveCount(1);
@@ -365,7 +365,7 @@ namespace POEApi.Model.Tests
             string fakeStashInfo = Encoding.UTF8.GetString(Files.SampleStashWithSynthesisItems);
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, string.Empty, string.Empty, Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, string.Empty, string.Empty, Realm.PC, false)).Returns(stream);
                 var stash = _model.GetStash(0, string.Empty, string.Empty, Realm.PC);
                 stash.Should().NotBeNull();
                 stash.Tabs.Should().HaveCount(1);
@@ -411,7 +411,7 @@ namespace POEApi.Model.Tests
 
             using (var stream = GenerateStreamFromString(fakeStashInfo))
             {
-                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC)).Returns(stream);
+                _mockTransport.Setup(m => m.GetStash(0, "", "", Realm.PC, false)).Returns(stream);
 
                 var stash = _model.GetStash(0, "", "", Realm.PC);
 


### PR DESCRIPTION
We need to be able to specify to an arbitrary ITransport implementation that we want to force refresh the stash tab.  This fixes a bug where, when using the CachedTransport, tabs would never be refreshed, since
forceRefresh would always be false.

Fixes #1029.