### PR TITLE
Dynamically update a loot filter

### DIFF
--- a/POEApi.Model/ItemFilterConfig.json
+++ b/POEApi.Model/ItemFilterConfig.json
@@ -1,0 +1,83 @@
+﻿{
+  "fileConfig": [
+    {
+      "disabled": true,
+      "inputLocation": "<ITEM FILTER DIRECTORY>\\NeverSink's filter - 1-REGULAR.filter",
+      "outputLocation": "<ITEM FILTER DIRECTORY>\\[MOD] NeverSink's filter - 1-REGULAR.filter",
+      "filterRuleConfig": [
+        {
+          "ruleType": "CHANCING_BASES",
+          "name": "Chancing Bases",
+          "searchString": "#   [1008] Chancing items\r\n#------------------------------------",
+          "searchStringRelation": "AFTER",
+          "additionalConfig": {
+            "@type": "type.googleapis.com/POEApi.Model.Protobuf.ChancingBasesFilterRuleConfig",
+            "otherCharactersStyling": "SECONDARY"
+          }
+        },
+        {
+          "ruleType": "MISSING_SAME_BASE_TYPE",
+          "name": "Missing Same Base Types",
+          "searchString": "#===============================================================================================================\r\n# [[0300]]",
+          "additionalConfig": {
+            "@type": "type.googleapis.com/POEApi.Model.Protobuf.MissingSameBaseTypesFilterRuleConfig"
+          }
+        }
+      ]
+    }
+  ],
+  "leagueConfig": [
+    {
+      "name": "SSF Legion",
+      "buildConfig": [
+        {
+          "buildName": "Freezing Pulse",
+          "chancingBase": [
+            {
+              "baseTypeName": "Occultist's Vestment",
+              "uniqueItemName": "Shavronne's Wrappings",
+              "quantityNeeded": 1
+            },
+            {
+              "baseTypeName": "Prophecy Wand",
+              "uniqueItemName": "Void Battery",
+              "quantityNeeded": 2
+            },
+            {
+              "baseTypeName": "Jade Amulet",
+              "uniqueItemName": "The Pandemonius",
+              "quantityNeeded": 1
+            },
+            {
+              "baseTypeName": "Cobalt Jewel",
+              "uniqueItemName": "First Snow",
+              "quantityNeeded": 2,
+              "quantityHeld": 1
+            },
+            {
+              "baseTypeName": "Cobalt Jewel",
+              "uniqueItemName": "Energy From Within",
+              "quantityNeeded": 1
+            }
+          ]
+        },
+        {
+          "buildName": "2h Freezing Cyclone",
+          "chancingBase": [
+            {
+              "baseTypeName": "Goathide Gloves",
+              "uniqueItemName": "Hrimsorrow",
+              "quantityNeeded": 1
+            },
+            {
+              "disabled": true,
+              "baseTypeName": "Nightmare Bascinet",
+              "uniqueItemName": "Devoto's Devotion",
+              "quantityNeeded": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/POEApi.Model/ItemFilterConfig.proto
+++ b/POEApi.Model/ItemFilterConfig.proto
@@ -1,0 +1,87 @@
+﻿syntax = "proto3";
+
+import "google/protobuf/any.proto";
+
+package POEApi.Model.Protobuf;
+
+message SemanticVersion {
+  int32 major = 1;
+  int32 minor = 2;
+  int32 revision = 3;
+}
+
+message MissingSameBaseTypesFilterRuleConfig {
+  bool disable_missing_normal_items = 1;
+  bool disable_missing_magic_items = 2;
+  bool disable_missing_rare_items = 3;
+  bool disable_missing_normal_quality_items = 4;
+  bool disable_missing_magic_quality_items = 5;
+  bool disable_missing_rare_quality_items = 6;
+}
+
+message ChancingBasesFilterRuleConfig {
+  enum ChancingBaseStyling {
+	PRIMARY = 0;
+	SECONDARY = 1;
+	UNSTYLED = 2;
+  }
+  ChancingBaseStyling current_character_styling = 5;
+  ChancingBaseStyling other_characters_styling = 6;
+}
+
+message FilterRuleConfig {
+  bool disabled = 1;
+  string name = 2;
+
+  string search_string = 3;
+
+  enum SearchStringRelation {
+	BEFORE = 0;
+	AFTER = 1;
+  }
+  SearchStringRelation search_string_relation = 4;
+
+  google.protobuf.Any additional_config = 5;
+}
+
+message FileConfig {
+  bool disabled = 1;
+  string input_location = 2;
+  string output_location = 3;
+
+  repeated FilterRuleConfig filter_rule_config = 4;
+}
+
+message ChancingBaseConfig {
+  bool disabled = 1;
+  string base_type_name = 2;
+  string unique_item_name = 3;
+
+  int32 quantity_held = 4;
+  int32 quantity_needed = 5;
+
+  string required_league = 6;
+}
+
+message BuildConfig {
+  bool disabled = 1;
+  string build_name = 2;
+  string character_name = 3;
+  repeated string stash_name = 4;
+
+  repeated ChancingBaseConfig chancing_base = 5;
+}
+
+message LeagueConfig {
+  bool disabled = 1;
+  string name = 2;
+
+  repeated BuildConfig build_config = 3;
+}
+
+message ItemFilterConfig {
+  SemanticVersion version = 1;
+
+  repeated FileConfig file_config = 2;
+  repeated LeagueConfig league_config = 3;
+}

--- a/POEApi.Model/ItemFilterConfig.proto
+++ b/POEApi.Model/ItemFilterConfig.proto
@@ -31,17 +31,24 @@ message ChancingBasesFilterRuleConfig {
 
 message FilterRuleConfig {
   bool disabled = 1;
-  string name = 2;
 
-  string search_string = 3;
+  enum FilterRuleType {
+    UNKNOWN = 0;
+    MISSING_SAME_BASE_TYPE = 1;
+    CHANCING_BASES = 2;
+  }
+  FilterRuleType rule_type = 2;
+  string name = 3;
+
+  string search_string = 4;
 
   enum SearchStringRelation {
 	BEFORE = 0;
 	AFTER = 1;
   }
-  SearchStringRelation search_string_relation = 4;
+  SearchStringRelation search_string_relation = 5;
 
-  google.protobuf.Any additional_config = 5;
+  google.protobuf.Any additional_config = 6;
 }
 
 message FileConfig {

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -170,6 +170,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Protobuf Include="ItemFilterConfig.proto" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.props" Condition="Exists('..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,6 +38,18 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Google.Protobuf, Version=3.8.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.8.0\lib\net45\Google.Protobuf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
+      <HintPath>..\packages\Grpc.Core.1.21.0\lib\net45\Grpc.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Grpc.Core.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
+      <HintPath>..\packages\Grpc.Core.Api.1.21.0\lib\net45\Grpc.Core.Api.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -42,6 +57,10 @@
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Interactive.Async, Version=3.2.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Interactive.Async.3.2.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -154,6 +173,16 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.props'))" />
+    <Error Condition="!Exists('..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.targets'))" />
+    <Error Condition="!Exists('..\packages\Grpc.Core.1.21.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.21.0\build\net45\Grpc.Core.targets'))" />
+  </Target>
+  <Import Project="..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.targets" Condition="Exists('..\packages\Grpc.Tools.1.21.0\build\Grpc.Tools.targets')" />
+  <Import Project="..\packages\Grpc.Core.1.21.0\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.21.0\build\net45\Grpc.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -171,6 +171,9 @@
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="ItemFilterConfig.proto" />
+    <None Include="ItemFilterConfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/POEApi.Model/Settings.cs
+++ b/POEApi.Model/Settings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
+using Google.Protobuf;
 using POEApi.Infrastructure;
 
 namespace POEApi.Model
@@ -13,6 +14,8 @@ namespace POEApi.Model
         private const string SaveLocation = "Settings.xml";
         private const string DataLocation = "Data.xml";
         private const string BuyoutLocation = "Buyouts.xml";
+        private const string ItemFilterConfigLocation = "ItemFilterConfig.json";
+        private static Google.Protobuf.Reflection.TypeRegistry ProtoTypeRegistry;
 
         public static Dictionary<OrbType, CurrencyRatio> CurrencyRatios { get; private set; }
         public static Dictionary<string, string> UserSettings { get; private set; }
@@ -21,6 +24,7 @@ namespace POEApi.Model
         public static Dictionary<string, ItemTradeInfo> Buyouts { get; private set; }
         public static Dictionary<string, string> TabsBuyouts { get; private set; }
         public static Dictionary<string, ShopSetting> ShopSettings { get; private set; }
+        public static Protobuf.ItemFilterConfig ItemFilterConfig { get; private set; }
         public static List<string> PopularGems { get; private set; }
         public static List<string> DropOnlyGems { get; private set; }
         private static XElement settingsFile;
@@ -58,6 +62,11 @@ namespace POEApi.Model
 
             LoadGearTypeData();
             LoadShopSettings();
+
+            ProtoTypeRegistry = Google.Protobuf.Reflection.TypeRegistry.FromMessages(
+                Protobuf.ChancingBasesFilterRuleConfig.Descriptor,
+                Protobuf.MissingSameBaseTypesFilterRuleConfig.Descriptor);
+            LoadItemFilterConfig();
         }
 
         private static void LoadBuyouts()
@@ -95,6 +104,29 @@ namespace POEApi.Model
         private static void LoadShopSettings()
         {
             ShopSettings = settingsFile.Elements("ShopSettings").Descendants().ToDictionary(shop => shop.Attribute("League").Value, shop => CreateShopSetting(shop));
+        }
+
+        private static void LoadItemFilterConfig()
+        {
+            if (!System.IO.File.Exists(ItemFilterConfigLocation))
+                return;
+
+            string jsonStringRead = System.IO.File.ReadAllText(ItemFilterConfigLocation);
+            var jsonParser = new JsonParser(new JsonParser.Settings(10, ProtoTypeRegistry));
+            try
+            {
+                ItemFilterConfig = jsonParser.Parse<Protobuf.ItemFilterConfig>(jsonStringRead);
+            }
+            catch (InvalidJsonException ex)
+            {
+                Logger.Log(string.Format("Failed to parse an ItemFilterConfig from the json string '{0}': {1}",
+                    jsonStringRead, ex.ToString()));
+            }
+            catch (System.InvalidOperationException ex)
+            {
+                Logger.Log(string.Format("Failed to parse an ItemFilterConfig from the json string '{0}': {1}",
+                    jsonStringRead, ex.ToString()));
+            }
         }
 
         private static ShopSetting CreateShopSetting(XElement shop)
@@ -282,6 +314,26 @@ namespace POEApi.Model
                 Logger.Log("Unable to save shop settings: " + ex.ToString());
                 return false;
             }
+        }
+
+        public static bool SaveItemFilterConfig()
+        {
+            if (ItemFilterConfig == null)
+                return true;
+
+            try
+            {
+                var formatter = new JsonFormatter(new JsonFormatter.Settings(false, ProtoTypeRegistry));
+                var jsonString = formatter.Format(ItemFilterConfig);
+                System.IO.File.WriteAllText(ItemFilterConfigLocation, jsonString);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Unable to save item filter config: " + ex.ToString());
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/POEApi.Model/packages.config
+++ b/POEApi.Model/packages.config
@@ -1,4 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Google.Protobuf" version="3.8.0" targetFramework="net45" />
+  <package id="Grpc" version="1.21.0" targetFramework="net45" />
+  <package id="Grpc.Core" version="1.21.0" targetFramework="net45" />
+  <package id="Grpc.Core.Api" version="1.21.0" targetFramework="net45" />
+  <package id="Grpc.Tools" version="1.21.0" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -61,6 +61,7 @@
     <ApplicationIcon>Images\Procurement.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Google.Protobuf, Version=3.8.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604" />
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -115,7 +115,7 @@
     <Compile Include="ViewModel\Filters\ForumExport\ResonatorFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\SynthesisedItemFilter.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\SimpleVisitor.cs" />
-    <Compile Include="ViewModel\LootFilterUpdater.cs" />
+    <Compile Include="ViewModel\ItemFilterUpdater.cs" />
     <Compile Include="ViewModel\Recipes\LoreweaveRecipe.cs" />
     <Compile Include="ViewModel\Recipes\VaalOrbRecipe.cs" />
     <Compile Include="ViewModel\TabViewModel\FragmentStashViewModel.cs" />

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -115,6 +115,7 @@
     <Compile Include="ViewModel\Filters\ForumExport\ResonatorFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\SynthesisedItemFilter.cs" />
     <Compile Include="ViewModel\ForumExportVisitors\SimpleVisitor.cs" />
+    <Compile Include="ViewModel\LootFilterUpdater.cs" />
     <Compile Include="ViewModel\Recipes\LoreweaveRecipe.cs" />
     <Compile Include="ViewModel\Recipes\VaalOrbRecipe.cs" />
     <Compile Include="ViewModel\TabViewModel\FragmentStashViewModel.cs" />

--- a/Procurement/ViewModel/ItemFilterUpdater.cs
+++ b/Procurement/ViewModel/ItemFilterUpdater.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Procurement.ViewModel
 {
-    class LootFilterUpdater
+    class ItemFilterUpdater
     {
         protected static Dictionary<Tab, List<Item>> GetUsableCurrentLeagueItemsByTab()
         {
@@ -38,7 +38,7 @@ namespace Procurement.ViewModel
                 .ToDictionary(g => g.Name, g => g.RecipeGroup.ToList());
         }
 
-        public static void UpdateLootFilter()
+        public static void UpdateLootFilters()
         {
             if (!bool.Parse(Settings.UserSettings["UpdateItemFilter"]))
                 return;

--- a/Procurement/ViewModel/ItemFilterUpdater.cs
+++ b/Procurement/ViewModel/ItemFilterUpdater.cs
@@ -1,4 +1,5 @@
-﻿using POEApi.Model;
+﻿using POEApi.Infrastructure;
+using POEApi.Model;
 using Procurement.ViewModel.Recipes;
 using System;
 using System.Collections.Generic;
@@ -40,34 +41,75 @@ namespace Procurement.ViewModel
 
         public static void UpdateLootFilters()
         {
-            if (!bool.Parse(Settings.UserSettings["UpdateItemFilter"]))
-                return;
-
-            string inputFilePath = Settings.UserSettings["ItemFilterFileInputPath"];
-            string outputFilePath = Settings.UserSettings["ItemFilterFileOutputPath"];
-            if (string.IsNullOrWhiteSpace(inputFilePath) || string.IsNullOrWhiteSpace(outputFilePath))
+            foreach (var fileConfig in Settings.ItemFilterConfig.FileConfig)
             {
-                // TODO: Log an error/message.
-                return;
+                if (!fileConfig.Disabled)
+                    UpdateLootFilter(fileConfig, Settings.ItemFilterConfig);
             }
-
-            string itemFilterText = System.IO.File.ReadAllText(inputFilePath);
-
-            if (bool.Parse(Settings.UserSettings["UseMissingSameBaseTypeItemFilters"]))
-            {
-                itemFilterText = AddMissingSameBaseTypeItemFilters(itemFilterText);
-            }
-
-            if (bool.Parse(Settings.UserSettings["UseChancingBasesItemFilters"]))
-            {
-                itemFilterText = AddChancingBasesItemFilters(itemFilterText);
-            }
-
-            System.IO.File.WriteAllText(outputFilePath, itemFilterText);
         }
 
-        protected static string AddMissingSameBaseTypeItemFilters(string itemFilterText)
+        public static void UpdateLootFilter(POEApi.Model.Protobuf.FileConfig fileConfig,
+            POEApi.Model.Protobuf.ItemFilterConfig itemFilterConfig)
         {
+            if (string.IsNullOrWhiteSpace(fileConfig.InputLocation) ||
+                string.IsNullOrWhiteSpace(fileConfig.OutputLocation))
+            {
+                Logger.Log("Must provide both an input and output location for an item filter file config.");
+                return;
+            }
+
+            string itemFilterText = "";
+            if (!System.IO.File.Exists(fileConfig.InputLocation))
+            {
+                Logger.Log(string.Format(
+                    "Input location '{0}' for item filter file confg does not exist; using empty base.",
+                    fileConfig.InputLocation));
+            }
+            else
+            {
+                itemFilterText = System.IO.File.ReadAllText(fileConfig.InputLocation);
+            }
+
+            foreach (var filterRuleConfig in fileConfig.FilterRuleConfig)
+            {
+                itemFilterText = ApplyFilterRule(itemFilterText, filterRuleConfig, itemFilterConfig);
+            }
+
+            System.IO.File.WriteAllText(fileConfig.OutputLocation, itemFilterText);
+        }
+
+        protected static string ApplyFilterRule(string itemFilterText,
+            POEApi.Model.Protobuf.FilterRuleConfig filterRuleConfig,
+            POEApi.Model.Protobuf.ItemFilterConfig itemFilterConfig)
+        {
+            switch (filterRuleConfig.RuleType)
+            {
+                case POEApi.Model.Protobuf.FilterRuleConfig.Types.FilterRuleType.MissingSameBaseType:
+                    return AddMissingSameBaseTypeItemFilters(itemFilterText, filterRuleConfig, itemFilterConfig);
+                case POEApi.Model.Protobuf.FilterRuleConfig.Types.FilterRuleType.ChancingBases:
+                    return AddChancingBasesItemFilters(itemFilterText, filterRuleConfig, itemFilterConfig);
+                default:
+                    Logger.Log(string.Format(
+                        "Unknown item filter rule type '{0}' found for rule with name '{1}'; skipping.",
+                        filterRuleConfig.RuleType.ToString(), filterRuleConfig.Name));
+                    break;
+            }
+
+            return itemFilterText;
+        }
+
+        protected static string AddMissingSameBaseTypeItemFilters(string itemFilterText,
+            POEApi.Model.Protobuf.FilterRuleConfig filterRuleConfig,
+            POEApi.Model.Protobuf.ItemFilterConfig itemFilterConfig)
+        {
+
+            var additionalConfig = new POEApi.Model.Protobuf.MissingSameBaseTypesFilterRuleConfig();
+            if (filterRuleConfig.AdditionalConfig.Is(POEApi.Model.Protobuf.MissingSameBaseTypesFilterRuleConfig.Descriptor))
+            {
+                additionalConfig = filterRuleConfig.AdditionalConfig.Unpack<
+                    POEApi.Model.Protobuf.MissingSameBaseTypesFilterRuleConfig>();
+            }
+
             var relaxedResults = GetRelaxedSameBaseTypeResults();
 
             var resultsMissingQualityBaseTypeItems = relaxedResults.SelectMany(category => category.Value)
@@ -75,37 +117,25 @@ namespace Procurement.ViewModel
                 .Where(result => result.PercentMatch < 100)
                 .Where(result => result.Name.Contains("20%"));
 
-            var normalQualityItemsNeeded = resultsMissingQualityBaseTypeItems
-                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Normal))
-                .Select(result => result.MatchedItems.First() as Gear)
-                .GroupBy(gear => new { gear.BaseType, gear.GearType })
-                .Select(group => group.First())
-                .OrderBy(gear => gear.BaseType);
-
-            var magicQualityItemsNeeded = resultsMissingQualityBaseTypeItems
-                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Magic))
-                .Select(result => result.MatchedItems.First() as Gear)
-                .GroupBy(gear => new { gear.BaseType, gear.GearType })
-                .Select(group => group.First())
-                .OrderBy(gear => gear.BaseType);
-
-            var rareQualityItemsNeeded = resultsMissingQualityBaseTypeItems
-                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Rare))
-                .Select(result => result.MatchedItems.First() as Gear)
-                .GroupBy(gear => new { gear.BaseType, gear.GearType })
-                .Select(group => group.First())
-                .OrderBy(gear => gear.BaseType);
-
             StringBuilder normalQualityItemsNeededFilter = new StringBuilder();
-            if (normalQualityItemsNeeded.Count() > 0)
+            if (!additionalConfig.DisableMissingNormalQualityItems)
             {
-                StringBuilder baseTypeLine = new StringBuilder();
-                foreach (var item in normalQualityItemsNeeded)
+                var normalQualityItemsNeeded = resultsMissingQualityBaseTypeItems
+                    .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Normal))
+                    .Select(result => result.MatchedItems.First() as Gear)
+                    .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                    .Select(group => group.First())
+                    .OrderBy(gear => gear.BaseType);
+
+                if (normalQualityItemsNeeded.Count() > 0)
                 {
-                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
-                }
-                normalQualityItemsNeededFilter.AppendFormat(
-@"#-------------------------------------------------
+                    StringBuilder baseTypeLine = new StringBuilder();
+                    foreach (var item in normalQualityItemsNeeded)
+                    {
+                        baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                    }
+                    normalQualityItemsNeededFilter.AppendFormat(
+    @"#-------------------------------------------------
 #   [0294] Missing Normal Rarity Items With Quality
 #-------------------------------------------------
 
@@ -123,18 +153,28 @@ Show # Missing normal rarity gear
 	SetBackgroundColor 75 75 75
 
 ", baseTypeLine.ToString());
+                }
             }
 
             StringBuilder magicQualityItemsNeededFilter = new StringBuilder();
-            if (magicQualityItemsNeeded.Count() > 0)
+            if (!additionalConfig.DisableMissingMagicQualityItems)
             {
-                StringBuilder baseTypeLine = new StringBuilder();
-                foreach (var item in magicQualityItemsNeeded)
+                var magicQualityItemsNeeded = resultsMissingQualityBaseTypeItems
+                    .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Magic))
+                    .Select(result => result.MatchedItems.First() as Gear)
+                    .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                    .Select(group => group.First())
+                    .OrderBy(gear => gear.BaseType);
+
+                if (magicQualityItemsNeeded.Count() > 0)
                 {
-                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
-                }
-                magicQualityItemsNeededFilter.AppendFormat(
-@"#------------------------------------------------
+                    StringBuilder baseTypeLine = new StringBuilder();
+                    foreach (var item in magicQualityItemsNeeded)
+                    {
+                        baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                    }
+                    magicQualityItemsNeededFilter.AppendFormat(
+    @"#------------------------------------------------
 #   [0295] Missing Magic Rarity Items With Quality
 #------------------------------------------------
 
@@ -152,18 +192,28 @@ Show # Missing magic rarity gear
 	SetBackgroundColor 75 75 75
 
 ", baseTypeLine.ToString());
+                }
             }
 
             StringBuilder rareQualityItemsNeededFilter = new StringBuilder();
-            if (rareQualityItemsNeeded.Count() > 0)
+            if (!additionalConfig.DisableMissingRareQualityItems)
             {
-                StringBuilder baseTypeLine = new StringBuilder();
-                foreach (var item in rareQualityItemsNeeded)
+                var rareQualityItemsNeeded = resultsMissingQualityBaseTypeItems
+                    .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Rare))
+                    .Select(result => result.MatchedItems.First() as Gear)
+                    .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                    .Select(group => group.First())
+                    .OrderBy(gear => gear.BaseType);
+
+                if (rareQualityItemsNeeded.Count() > 0)
                 {
-                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
-                }
-                rareQualityItemsNeededFilter.AppendFormat(
-@"#-----------------------------------------------
+                    StringBuilder baseTypeLine = new StringBuilder();
+                    foreach (var item in rareQualityItemsNeeded)
+                    {
+                        baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                    }
+                    rareQualityItemsNeededFilter.AppendFormat(
+    @"#-----------------------------------------------
 #   [0296] Missing Rare Rarity Items With Quality
 #-----------------------------------------------
 
@@ -181,6 +231,7 @@ Show # Missing rare rarity gear
 	SetBackgroundColor 75 75 75
 
 ", baseTypeLine.ToString());
+                }
             }
 
             var resultsMissingNonQualityBaseTypeItems = relaxedResults.SelectMany(category => category.Value)
@@ -189,37 +240,25 @@ Show # Missing rare rarity gear
                 .Where(result => result.Name.Contains("(U)"))
                 .Where(result => !result.Name.Contains("20%"));
 
-            var normalItemsNeeded = resultsMissingNonQualityBaseTypeItems
-                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Normal))
-                .Select(result => result.MatchedItems.First() as Gear)
-                .GroupBy(gear => new { gear.BaseType, gear.GearType })
-                .Select(group => group.First())
-                .OrderBy(gear => gear.BaseType);
-
-            var magicItemsNeeded = resultsMissingNonQualityBaseTypeItems
-                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Magic))
-                .Select(result => result.MatchedItems.First() as Gear)
-                .GroupBy(gear => new { gear.BaseType, gear.GearType })
-                .Select(group => group.First())
-                .OrderBy(gear => gear.BaseType);
-
-            var rareItemsNeeded = resultsMissingNonQualityBaseTypeItems
-                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Rare))
-                .Select(result => result.MatchedItems.First() as Gear)
-                .GroupBy(gear => new { gear.BaseType, gear.GearType })
-                .Select(group => group.First())
-                .OrderBy(gear => gear.BaseType);
-
             StringBuilder normalItemsNeededFilter = new StringBuilder();
-            if (normalItemsNeeded.Count() > 0)
+            if (!additionalConfig.DisableMissingNormalItems)
             {
-                StringBuilder baseTypeLine = new StringBuilder();
-                foreach (var item in normalItemsNeeded)
+                var normalItemsNeeded = resultsMissingNonQualityBaseTypeItems
+                    .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Normal))
+                    .Select(result => result.MatchedItems.First() as Gear)
+                    .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                    .Select(group => group.First())
+                    .OrderBy(gear => gear.BaseType);
+
+                if (normalItemsNeeded.Count() > 0)
                 {
-                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
-                }
-                normalItemsNeededFilter.AppendFormat(
-@"#------------------------------------
+                    StringBuilder baseTypeLine = new StringBuilder();
+                    foreach (var item in normalItemsNeeded)
+                    {
+                        baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                    }
+                    normalItemsNeededFilter.AppendFormat(
+    @"#------------------------------------
 #   [0298] Missing Normal Rarity Items
 #------------------------------------
 # Normal items needed to compete the same-base-type recipes.
@@ -236,18 +275,28 @@ Show # Missing normal rarity gear
 	SetBackgroundColor 75 75 75
 
 ", baseTypeLine.ToString());
-            };
+                };
+            }
 
             StringBuilder magicItemsNeededFilter = new StringBuilder();
-            if (magicItemsNeeded.Count() > 0)
+            if (!additionalConfig.DisableMissingMagicItems)
             {
-                StringBuilder baseTypeLine = new StringBuilder();
-                foreach (var item in magicItemsNeeded)
+                var magicItemsNeeded = resultsMissingNonQualityBaseTypeItems
+                    .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Magic))
+                    .Select(result => result.MatchedItems.First() as Gear)
+                    .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                    .Select(group => group.First())
+                    .OrderBy(gear => gear.BaseType);
+
+                if (magicItemsNeeded.Count() > 0)
                 {
-                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
-                }
-                magicItemsNeededFilter.AppendFormat(
-@"#------------------------------------
+                    StringBuilder baseTypeLine = new StringBuilder();
+                    foreach (var item in magicItemsNeeded)
+                    {
+                        baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                    }
+                    magicItemsNeededFilter.AppendFormat(
+    @"#------------------------------------
 #   [0298b] Missing Magic Rarity Items
 #------------------------------------
 # Magic items needed to compete the same-base-type recipes.
@@ -264,18 +313,28 @@ Show # Missing magic rarity gear
 	SetBackgroundColor 75 75 75
 
 ", baseTypeLine.ToString());
-            };
+                };
+            }
 
             StringBuilder rareItemsNeededFilter = new StringBuilder();
-            if (rareItemsNeeded.Count() > 0)
+            if (!additionalConfig.DisableMissingRareItems)
             {
-                StringBuilder baseTypeLine = new StringBuilder();
-                foreach (var item in rareItemsNeeded)
+                var rareItemsNeeded = resultsMissingNonQualityBaseTypeItems
+                    .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Rare))
+                    .Select(result => result.MatchedItems.First() as Gear)
+                    .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                    .Select(group => group.First())
+                    .OrderBy(gear => gear.BaseType);
+
+                if (rareItemsNeeded.Count() > 0)
                 {
-                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
-                }
-                rareItemsNeededFilter.AppendFormat(
-@"#------------------------------------
+                    StringBuilder baseTypeLine = new StringBuilder();
+                    foreach (var item in rareItemsNeeded)
+                    {
+                        baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                    }
+                    rareItemsNeededFilter.AppendFormat(
+    @"#------------------------------------
 #   [0298c] Missing Rare Rarity Items
 #------------------------------------
 # Rare items needed to compete the same-base-type recipes.
@@ -292,286 +351,55 @@ Show # Missing Rare rarity gear
 	SetBackgroundColor 75 75 75
 
 ", baseTypeLine.ToString());
-            };
+                };
+            }
 
-            /*
-string allFilters = string.Format("{0}\n{1}", normalItemsNeededFilter.ToString(),
-    chanceItemsFilter.ToString());
-    */
             string allFilters = string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n{5}", normalQualityItemsNeededFilter.ToString(),
                 magicQualityItemsNeededFilter.ToString(), rareQualityItemsNeededFilter.ToString(),
                 normalItemsNeededFilter.ToString(), magicItemsNeededFilter.ToString(),
                 rareItemsNeededFilter.ToString());
 
-            const string customOverridesSearchString = @"#===============================================================================================================
-# [[0300]]";
-
-            var matchLocation = itemFilterText.IndexOf(customOverridesSearchString);
+            var matchLocation = itemFilterText.IndexOf(filterRuleConfig.SearchString);
             if (matchLocation < 0)
             {
                 matchLocation = 0;
             }
+            else if (filterRuleConfig.SearchStringRelation ==
+                POEApi.Model.Protobuf.FilterRuleConfig.Types.SearchStringRelation.After)
+            {
+                matchLocation += filterRuleConfig.SearchString.Length;
+            }
+
             return itemFilterText.Insert(matchLocation, allFilters);
         }
 
-        protected static string AddChancingBasesItemFilters(string itemFilterText)
+        protected static string AddChancingBasesItemFilters(string itemFilterText,
+            POEApi.Model.Protobuf.FilterRuleConfig filterRuleConfig,
+            POEApi.Model.Protobuf.ItemFilterConfig itemFilterConfig)
         {
-            // TODO: Automate setting these items.
-            List<string> chanceItems;
-            switch (ApplicationState.CurrentLeague)
+            if (filterRuleConfig.Disabled)
+                return itemFilterText;
+
+            List<string> chanceItems = new List<string>();
+            foreach (var leagueConfig in itemFilterConfig.LeagueConfig)
             {
-                case "SSF Synthesis":
-                    chanceItems = new List<string>
+                if (!leagueConfig.Disabled && string.Equals(leagueConfig.Name, ApplicationState.CurrentLeague))
+                {
+                    foreach (var buildConfig in leagueConfig.BuildConfig)
                     {
-                        // Enki's Arc Witch
-                        // TODO: Have to check what's actually required or
-                        // recommended.  Lots of dense information in the guide.
-                        "Sadist Garb",  // Inpulsa's Broken Heart
-                        "Royal Skean",  // Heartbreaker (optional)
-
-                        // Bella's Dancing Duo Occultist
-                        // https://www.pathofexile.com/forum/view-thread/2235258
-                        // "Reaver Sword",  // The Dancing Duo (obtained)
-                        "Occultist's Vestment",  // Shavronne's Wrappings
-                        "Riveted Gloves",  // Command of the Pit
-                        "Hallowed Hybrid Flask",  // The Writhing Jar (x3)
-                        "Deicide Mask",  // Heretic's Veil (optional)
-                        "Onyx Amulet",  // Aul's Uprising, Envy Edition (optional)
-
-                        // Popcorn Skeletons
-                        "Grinning Fetish",  // Earendel's Embrace (x2) (obtained 1/2)
-                        "Compound Spiked Shield",  // Maligaro's Lense (optional)
-                        "Bone Armour",  // Bloodbond (optional?)
-                        "Soldier Boots",  // Alberon's Warpath
-                        "Embroidered Gloves",  // Vixen's Entrapment
-
-                        // Whispering Ice CI Elequisitor
-                        "Vile Staff",  // The Whispering Ice (required!)
-                        "Onyx Amulet",  // Astramentis
-                        "Leather Belt",  // Cyclopean Coil
-                        "Cobalt Jewel",  // Fertile Mind (x2)
-                        "Crimson Jewel",  // Brute Force Solution
-                        "Crimson Jewel",  // Izaro's Turmoil
-                        "Viridian Jewel",  // Pure Talent
-
-                        // Mjolner Discharge
-                        "Gavel",  // Mjölner
-                        "Conquest Chainmail",  // Kingsguard
-                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
-                        "Diamond Ring",  // Romira's Banquet
-                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
-                        "Viridian Jewel",  // The Golden Rule
-                    };
-                    break;
-                case "Synthesis":
-                    chanceItems = new List<string>
-                    {
-                        // Toasters HC Occultist Support – 7 Auras + 4 Curses
-                        // https://www.pathofexile.com/forum/view-thread/2126677
-                        "Lacquered Garb",  // Victario's Influence (required)
-                        "Archon Kite Shield",  // Prism Guardian (required)
-                        "Prophet Crown",  // The Broken Crown (required)
-                        "Paua Ring",  // Doedre’s Damning
-                        "Onyx Amulet",  // Impresence
-                        "War Hammer",  // Brightbeak (optional)
-                        "Stealth Boots",  // Sin Trek (optional)
-                        "Samite Gloves",  // Kalista's Grace (optional)
-                    };
-                    break;
-                case "SSF Betrayal":
-                    chanceItems = new List<string>
-                    {
-                        "Ranger Bow",  // Null's Inclination (required)
-                        "Lacquered Garb",  // Victario's Influence (required)
-                        "Prophet Crown",  // Speaker's Wreath (required)
-                        // "Riveted Gloves",  // Command of the Pit (drop-only from a delve boss?)
-
-                        // Enki's Arc Witch
-                        // TODO: Have to check what's actually required or
-                        // recommended.  Lots of dense information in the guide.
-                        "Sadist Garb",  // Inpulsa's Broken Heart
-
-                        // Lightning Tendrils CwC Arc
-                        // "Harlequin Mask",  // Mind of the Council (only from Unbearable Whispers prophecy chain).
-                        "Sadist Garb",  // Inpulsa's Broken Heart
-                        "Lapis Amulet",  // Choir of the Storm (optional)
-
-                        // Incinerate/Fireball Ignite Elementalist
-                        "Lathi",  // The Searing Touch
-                        "Samite Helmet",  // Hrimnor's Resolve
-                        "Glorious Plate",  // Kaom's Heart
-                        "Ruby Ring",  // Emberwake (x2)
-                        "Onyx Amulet",  // Impresence
-                        "Bismuth Flask",  // The Wise Oak
-                        "Viridian Jewel",  // Grand Spectrum (x3)
-
-                        // Whispering Ice CI Elequisitor
-                        // "Vile Staff",  // The Whispering Ice (required!) (obtained)
-                        "Onyx Amulet",  // Astramentis
-                        "Leather Belt",  // Cyclopean Coil
-                        "Cobalt Jewel",  // Fertile Mind (x2)
-                        "Crimson Jewel",  // Brute Force Solution
-                        "Crimson Jewel",  // Izaro's Turmoil
-                        "Viridian Jewel",  // Pure Talent
-
-                        // Mjolner Discharge
-                        "Gavel",  // Mjölner
-                        // "Conquest Chainmail",  // Kingsguard (obtained)
-                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
-                        "Diamond Ring",  // Romira's Banquet
-                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
-                        "Viridian Jewel",  // The Golden Rule
-                    };
-                    break;
-                case "SSF Delve":
-                    chanceItems = new List<string>
-                    {
-                        // Triple Herald Blade Vortex Elementalist
-                        "Sadist Garb",  // Inpulsa's Broken Heart
-                        // "Silken Hood",  // Starkonja's Head [obtained]
-                        "Goathide Gloves",  // Hrimsorrow
-                        // "Amethyst Flask",  // Atziri's Promise (can not be chanced)
-                        "Sapphire Flask",  // Taste of Hate
-
-                        // Enki's Arc Witch
-                        // TODO: Have to check what's actually required or
-                        // recommended.  Lots of dense information in the guide.
-
-                        // Whispering Ice CI Elequisitor
-                        // "Vile Staff",  // The Whispering Ice (required!) [obtained]
-                        "Onyx Amulet",  // Astramentis
-                        "Leather Belt",  // Cyclopean Coil
-                        "Cobalt Jewel",  // Fertile Mind (x2)
-                        "Crimson Jewel",  // Brute Force Solution
-                        "Crimson Jewel",  // Izaro's Turmoil
-                        "Viridian Jewel",  // Pure Talent
-
-                        // Mjolner Discharge
-                        "Gavel",  // Mjölner
-                        // "Conquest Chainmail",  // Kingsguard [obtained]
-                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
-                        "Diamond Ring",  // Romira's Banquet
-                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
-                        "Viridian Jewel",  // The Golden Rule
-                    };
-                    break;
-                case "SSF Incursion":
-                    chanceItems = new List<string>
-                    {
-                        // Mjolner Discharge
-                        "Gavel",  // Mjölner
-                        "Conquest Chainmail",  // Kingsguard
-                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
-                        "Diamond Ring",  // Romira's Banquet
-                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
-                        "Viridian Jewel",  // The Golden Rule
-
-                        // Elemental Wander
-                        "Tarnished Spirit Shield",  // Brinerot Flag (optional)
-                        "Destiny Leather",  // Queen of the Forest
-                        "Ursine Pelt",  // Rat's Nest
-                        "Topaz Flask",  // Vessel of Vinktar
-                        "Ruby Flask",  // Dying Sun
-                        "Bismuth Flask",  // The Wise Oak
-                        "Viridian Jewel",  // Static Electricity
-                        "Cobalt Jewel",  // Conqueror's Potency
-
-                        // CI Caustic Arrow
-                        "Spike-Point Arrow Quiver",  // Soul Strike
-                        "Onyx Amulet",  // Impresence
-                        "Stibnite Flask",  // Witchfire Brew
-                        "Ruby Flask",  // Dying Sun
-
-                        // Golemancer
-                        "Prismatic Jewel",  // The Anima Stone (also from vendor recipe using other uniques)
-                        "Cobalt Jewel",  // Primordial Harmony (x9)
-                        "Crimson Jewel",  // Primordial Might
-                        "Viridian Jewel",  // Primordial Eminence (x1, for The Anima Stone recipe)
-                        "Rock Breaker",  // Clayshaper (0/2 obtained)
-                        "Vaal Mask",  // The Vertex
-                        // "Unset Ring",  // Redblade Band (Warbands exclusive)
-                        // "Full Wyrmscale",  // Belly of the Beast (not needed in this build)
-
-                        // SRS/Zombies Necromancer
-                        "Elegant Ringmail",  // Geofri's Sanctuary
-                        "Crusader Gloves",  // Shaper's Touch
-                        "Close Helmet",  // The Baron
-                        "Void Sceptre",  // Mon'tregul's Grasp
-                        "Onyx Amulet",  // Astramentis
-                        "Soldier Boots",  // Alberon's Warpath
-                        "Cobalt Jewel",  // Violent Dead (x2)
-                        "Crimson Jewel",  // Efficient Training (x3)
-                        "Crimson Jewel",  // Brawn (x2-3)
-                    };
-                    break;
-                case "SSF Standard":
-                    chanceItems = new List<string>
-                    {
-                        // SR/RF Totems
-                        "Spidersilk Robe",  // Soul Mantle
-                        // "Vaal Sceptre",  // Doryani's Catalyst (can not be chanced)
-                        "Pinnacle Tower Shield",  // Lioneye's Remorse
-                        // "Samite Helmet",  // Hrimnor's Resolve (obtained)
-                        "Topaz Ring",  // Kikazaru (2x)
-                        "Crimson Jewel",  // Spire of Stone
-                        "Viridian Jewel",  // Self-Flagellation
-
-                        // Elemental Wander
-                        "Tarnished Spirit Shield",  // Brinerot Flag (optional)
-                        // "Destiny Leather",  // Queen of the Forest (obtained)
-                        "Ursine Pelt",  // Rat's Nest
-                        "Topaz Flask",  // Vessel of Vinktar
-                        "Ruby Flask",  // Dying Sun
-                        // "Bismuth Flsk",  // The Wise Oak (obtained)
-                        "Viridian Jewel",  // Static Electricity
-                        "Cobalt Jewel",  // Conqueror's Potency
-                    };
-                    break;
-                case "SSF Bestiary":
-                    chanceItems = new List<string>
-                    {
-                        // Frost Wind Ascendant
-                        "Imperial Skean",  // White Wind
-                        "Nubuck Gloves",  // Oskarm
-                        "Full Wyrmscale",  // Belly of the Beast
-
-                        // Magma Orb MoM Caster
-                        "Paua Ring",  // Doedre's Damning
-                        "Blue Pearl Amulet",  // Gloomfang
-                        // "Amethyst Flask",  // Atziri's Promise (can not be chanced)
-                        // "Cobalt Jewel",  // Inevitability (2/2 obtained)
-
-                        // SRS/Zombies Necromancer
-                        "Spidersilk Robe",  // The Covenant
-                        // "Close Helmet",  // The Baron (obtained)
-                        "Void Sceptre",  // Mon'tregul's Grasp
-                        "Onyx Amulet",  // Astramentis
-                        "Colossal Tower Shield",  // Ahn's Heritage
-                        "Crimson Jewel",  // Fragility (x2)
-                        "Soldier Boots",  // Alberon's Warpath
-                        "Crimson Jewel",  // Efficient Training (x2)
-                        "Cobalt Jewel",  // Violent Dead (x2)
-                        "Laminated Kite Shield",  // Victario's Charity (Necromantic Aegis variant)
-                        "Rawhide Tower Shield",  // Lycosidae (Necromantic Aegis variant)
-                    };
-                    break;
-                case "Bestiary":
-                    chanceItems = new List<string>
-                    {
-                        // Golemancer
-                        "Prismatic Jewel",  // The Anima Stone (also from vendor recipe using other uniques)
-                        "Cobalt Jewel",  // Primordial Harmony (x9)
-                        "Crimson Jewel",  // Primordial Might
-                        "Viridian Jewel",  // Primordial Eminence (x1, for The Anima Stone recipe)
-                        "Rock Breaker",  // Clayshaper (1/2 obtained)
-                        "Secutor Helm",  // Skullhead (expensive alternative)
-                        // "Unset Ring",  // Redblade Band (Warbands exclusive)
-                        "Full Wyrmscale",  // Belly of the Beast (very much optional)
-                    };
-                    break;
-                default:
-                    chanceItems = new List<string>();
-                    break;
+                        if (buildConfig.Disabled)
+                            continue;
+                        foreach (var chancingBase in buildConfig.ChancingBase)
+                        {
+                            if (chancingBase.Disabled)
+                                continue;
+                            if (chancingBase.QuantityHeld < chancingBase.QuantityNeeded)
+                            {
+                                chanceItems.Add(chancingBase.BaseTypeName);
+                            }
+                        }
+                    }
+                }
             }
             chanceItems = chanceItems.Distinct().ToList();
 
@@ -599,16 +427,17 @@ Show # $Chancing B-T1-Chancing %D4
 ", baseTypeLine.ToString());
             }
 
-            const string chancingBasesSearchString = @"#   [0710] Chancing items
-#------------------------------------
-# You can add your own items here. The items in this section have a dropsound";
-            var matchLocation = itemFilterText.IndexOf(chancingBasesSearchString);
+            var matchLocation = itemFilterText.IndexOf(filterRuleConfig.SearchString);
             if (matchLocation < 0)
             {
                 matchLocation = 0;
             }
-            return itemFilterText.Insert(matchLocation + chancingBasesSearchString.Length,
-                chanceItemsFilter.ToString());
+            else if (filterRuleConfig.SearchStringRelation ==
+                POEApi.Model.Protobuf.FilterRuleConfig.Types.SearchStringRelation.After)
+            {
+                matchLocation += filterRuleConfig.SearchString.Length;
+            }
+            return itemFilterText.Insert(matchLocation, chanceItemsFilter.ToString());
         }
     }
 }

--- a/Procurement/ViewModel/LootFilterUpdater.cs
+++ b/Procurement/ViewModel/LootFilterUpdater.cs
@@ -1,0 +1,614 @@
+﻿using POEApi.Model;
+using Procurement.ViewModel.Recipes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Procurement.ViewModel
+{
+    class LootFilterUpdater
+    {
+        protected static Dictionary<Tab, List<Item>> GetUsableCurrentLeagueItemsByTab()
+        {
+            Dictionary<Tab, List<Item>> itemsByTab = new Dictionary<Tab, List<Item>>();
+            Stash stash = ApplicationState.Stash[ApplicationState.CurrentLeague];
+
+            var usableTabs = stash.Tabs.Where(t => !Settings.Lists["IgnoreTabsInRecipes"].Contains(t.Name)).ToList();
+            foreach (var tab in usableTabs)
+            {
+                itemsByTab.Add(tab, stash.GetItemsByTab(tab.i));
+            }
+
+            return itemsByTab;
+        }
+
+        protected static Dictionary<string, List<RecipeResult>> GetRelaxedSameBaseTypeResults()
+        {
+            var itemsByTab = GetUsableCurrentLeagueItemsByTab();
+            SameBaseTypeRecipe sameBaseTypeRecipe = new SameBaseTypeRecipe(30);
+            return sameBaseTypeRecipe.Matches(itemsByTab)
+                .GroupBy(r => r.Name)
+                .Select(group => new
+                {
+                    Name = group.Key,
+                    RecipeGroup = group.OrderByDescending(recipe => recipe.PercentMatch)
+                })
+                .ToDictionary(g => g.Name, g => g.RecipeGroup.ToList());
+        }
+
+        public static void UpdateLootFilter()
+        {
+            if (!bool.Parse(Settings.UserSettings["UpdateItemFilter"]))
+                return;
+
+            string inputFilePath = Settings.UserSettings["ItemFilterFileInputPath"];
+            string outputFilePath = Settings.UserSettings["ItemFilterFileOutputPath"];
+            if (string.IsNullOrWhiteSpace(inputFilePath) || string.IsNullOrWhiteSpace(outputFilePath))
+            {
+                // TODO: Log an error/message.
+                return;
+            }
+
+            string itemFilterText = System.IO.File.ReadAllText(inputFilePath);
+
+            if (bool.Parse(Settings.UserSettings["UseMissingSameBaseTypeItemFilters"]))
+            {
+                itemFilterText = AddMissingSameBaseTypeItemFilters(itemFilterText);
+            }
+
+            if (bool.Parse(Settings.UserSettings["UseChancingBasesItemFilters"]))
+            {
+                itemFilterText = AddChancingBasesItemFilters(itemFilterText);
+            }
+
+            System.IO.File.WriteAllText(outputFilePath, itemFilterText);
+        }
+
+        protected static string AddMissingSameBaseTypeItemFilters(string itemFilterText)
+        {
+            var relaxedResults = GetRelaxedSameBaseTypeResults();
+
+            var resultsMissingQualityBaseTypeItems = relaxedResults.SelectMany(category => category.Value)
+                .Where(result => result.Instance is SameBaseTypeRecipe)
+                .Where(result => result.PercentMatch < 100)
+                .Where(result => result.Name.Contains("20%"));
+
+            var normalQualityItemsNeeded = resultsMissingQualityBaseTypeItems
+                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Normal))
+                .Select(result => result.MatchedItems.First() as Gear)
+                .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                .Select(group => group.First())
+                .OrderBy(gear => gear.BaseType);
+
+            var magicQualityItemsNeeded = resultsMissingQualityBaseTypeItems
+                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Magic))
+                .Select(result => result.MatchedItems.First() as Gear)
+                .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                .Select(group => group.First())
+                .OrderBy(gear => gear.BaseType);
+
+            var rareQualityItemsNeeded = resultsMissingQualityBaseTypeItems
+                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Rare))
+                .Select(result => result.MatchedItems.First() as Gear)
+                .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                .Select(group => group.First())
+                .OrderBy(gear => gear.BaseType);
+
+            StringBuilder normalQualityItemsNeededFilter = new StringBuilder();
+            if (normalQualityItemsNeeded.Count() > 0)
+            {
+                StringBuilder baseTypeLine = new StringBuilder();
+                foreach (var item in normalQualityItemsNeeded)
+                {
+                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                }
+                normalQualityItemsNeededFilter.AppendFormat(
+@"#-------------------------------------------------
+#   [0294] Missing Normal Rarity Items With Quality
+#-------------------------------------------------
+
+# Normal items needed to compete the same-base-type recipes with quality.
+
+Show # Missing normal rarity gear
+	BaseType{0}
+	Quality >= 10
+	Rarity = Normal
+	ElderItem False
+	ShaperItem False
+	SetFontSize 40
+	SetTextColor 255 255 255 255
+	SetBorderColor 255 255 255 200
+	SetBackgroundColor 75 75 75
+
+", baseTypeLine.ToString());
+            }
+
+            StringBuilder magicQualityItemsNeededFilter = new StringBuilder();
+            if (magicQualityItemsNeeded.Count() > 0)
+            {
+                StringBuilder baseTypeLine = new StringBuilder();
+                foreach (var item in magicQualityItemsNeeded)
+                {
+                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                }
+                magicQualityItemsNeededFilter.AppendFormat(
+@"#------------------------------------------------
+#   [0295] Missing Magic Rarity Items With Quality
+#------------------------------------------------
+
+# Magic items needed to compete the same-base-type recipes with quality.
+
+Show # Missing magic rarity gear
+	BaseType{0}
+	Quality >= 14
+	Rarity = Magic
+	ElderItem False
+	ShaperItem False
+	SetFontSize 40
+	#SetTextColor 25 95 235 255  # blue-ish
+	SetBorderColor 255 255 255 200
+	SetBackgroundColor 75 75 75
+
+", baseTypeLine.ToString());
+            }
+
+            StringBuilder rareQualityItemsNeededFilter = new StringBuilder();
+            if (rareQualityItemsNeeded.Count() > 0)
+            {
+                StringBuilder baseTypeLine = new StringBuilder();
+                foreach (var item in rareQualityItemsNeeded)
+                {
+                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                }
+                rareQualityItemsNeededFilter.AppendFormat(
+@"#-----------------------------------------------
+#   [0296] Missing Rare Rarity Items With Quality
+#-----------------------------------------------
+
+# Rare items needed to compete the same-base-type recipes with quality.
+
+Show # Missing rare rarity gear
+	BaseType{0}
+	Quality >= 16
+	Rarity = Rare
+	ElderItem False
+	ShaperItem False
+	SetFontSize 40
+	#SetTextColor 210 178 135 255
+	SetBorderColor 255 255 255 200
+	SetBackgroundColor 75 75 75
+
+", baseTypeLine.ToString());
+            }
+
+            var resultsMissingNonQualityBaseTypeItems = relaxedResults.SelectMany(category => category.Value)
+                .Where(result => result.Instance is SameBaseTypeRecipe)
+                .Where(result => result.PercentMatch < 100)
+                .Where(result => result.Name.Contains("(U)"))
+                .Where(result => !result.Name.Contains("20%"));
+
+            var normalItemsNeeded = resultsMissingNonQualityBaseTypeItems
+                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Normal))
+                .Select(result => result.MatchedItems.First() as Gear)
+                .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                .Select(group => group.First())
+                .OrderBy(gear => gear.BaseType);
+
+            var magicItemsNeeded = resultsMissingNonQualityBaseTypeItems
+                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Magic))
+                .Select(result => result.MatchedItems.First() as Gear)
+                .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                .Select(group => group.First())
+                .OrderBy(gear => gear.BaseType);
+
+            var rareItemsNeeded = resultsMissingNonQualityBaseTypeItems
+                .Where(result => result.MatchedItems.All(item => (item as Gear).Rarity != Rarity.Rare))
+                .Select(result => result.MatchedItems.First() as Gear)
+                .GroupBy(gear => new { gear.BaseType, gear.GearType })
+                .Select(group => group.First())
+                .OrderBy(gear => gear.BaseType);
+
+            StringBuilder normalItemsNeededFilter = new StringBuilder();
+            if (normalItemsNeeded.Count() > 0)
+            {
+                StringBuilder baseTypeLine = new StringBuilder();
+                foreach (var item in normalItemsNeeded)
+                {
+                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                }
+                normalItemsNeededFilter.AppendFormat(
+@"#------------------------------------
+#   [0298] Missing Normal Rarity Items
+#------------------------------------
+# Normal items needed to compete the same-base-type recipes.
+
+Show # Missing normal rarity gear
+	BaseType{0}
+	Quality = 0
+	Rarity = Normal
+	ElderItem False
+	ShaperItem False
+	SetFontSize 36
+	SetTextColor 210 178 135 255
+	SetBorderColor 213 159 100 200
+	SetBackgroundColor 75 75 75
+
+", baseTypeLine.ToString());
+            };
+
+            StringBuilder magicItemsNeededFilter = new StringBuilder();
+            if (magicItemsNeeded.Count() > 0)
+            {
+                StringBuilder baseTypeLine = new StringBuilder();
+                foreach (var item in magicItemsNeeded)
+                {
+                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                }
+                magicItemsNeededFilter.AppendFormat(
+@"#------------------------------------
+#   [0298b] Missing Magic Rarity Items
+#------------------------------------
+# Magic items needed to compete the same-base-type recipes.
+
+Show # Missing magic rarity gear
+	BaseType{0}
+	Quality = 0
+	Rarity = Magic
+	ElderItem False
+	ShaperItem False
+	SetFontSize 36
+	#SetTextColor 210 178 135 255
+	SetBorderColor 213 159 100 200
+	SetBackgroundColor 75 75 75
+
+", baseTypeLine.ToString());
+            };
+
+            StringBuilder rareItemsNeededFilter = new StringBuilder();
+            if (rareItemsNeeded.Count() > 0)
+            {
+                StringBuilder baseTypeLine = new StringBuilder();
+                foreach (var item in rareItemsNeeded)
+                {
+                    baseTypeLine.AppendFormat(" \"{0}\"", item.BaseType);
+                }
+                rareItemsNeededFilter.AppendFormat(
+@"#------------------------------------
+#   [0298c] Missing Rare Rarity Items
+#------------------------------------
+# Rare items needed to compete the same-base-type recipes.
+
+Show # Missing Rare rarity gear
+	BaseType{0}
+	Quality = 0
+	Rarity = Rare
+	ElderItem False
+	ShaperItem False
+	SetFontSize 36
+	#SetTextColor 210 178 135 255
+	SetBorderColor 213 159 100 200
+	SetBackgroundColor 75 75 75
+
+", baseTypeLine.ToString());
+            };
+
+            /*
+string allFilters = string.Format("{0}\n{1}", normalItemsNeededFilter.ToString(),
+    chanceItemsFilter.ToString());
+    */
+            string allFilters = string.Format("{0}\n{1}\n{2}\n{3}\n{4}\n{5}", normalQualityItemsNeededFilter.ToString(),
+                magicQualityItemsNeededFilter.ToString(), rareQualityItemsNeededFilter.ToString(),
+                normalItemsNeededFilter.ToString(), magicItemsNeededFilter.ToString(),
+                rareItemsNeededFilter.ToString());
+
+            const string customOverridesSearchString = @"#===============================================================================================================
+# [[0300]]";
+
+            var matchLocation = itemFilterText.IndexOf(customOverridesSearchString);
+            if (matchLocation < 0)
+            {
+                matchLocation = 0;
+            }
+            return itemFilterText.Insert(matchLocation, allFilters);
+        }
+
+        protected static string AddChancingBasesItemFilters(string itemFilterText)
+        {
+            // TODO: Automate setting these items.
+            List<string> chanceItems;
+            switch (ApplicationState.CurrentLeague)
+            {
+                case "SSF Synthesis":
+                    chanceItems = new List<string>
+                    {
+                        // Enki's Arc Witch
+                        // TODO: Have to check what's actually required or
+                        // recommended.  Lots of dense information in the guide.
+                        "Sadist Garb",  // Inpulsa's Broken Heart
+                        "Royal Skean",  // Heartbreaker (optional)
+
+                        // Bella's Dancing Duo Occultist
+                        // https://www.pathofexile.com/forum/view-thread/2235258
+                        // "Reaver Sword",  // The Dancing Duo (obtained)
+                        "Occultist's Vestment",  // Shavronne's Wrappings
+                        "Riveted Gloves",  // Command of the Pit
+                        "Hallowed Hybrid Flask",  // The Writhing Jar (x3)
+                        "Deicide Mask",  // Heretic's Veil (optional)
+                        "Onyx Amulet",  // Aul's Uprising, Envy Edition (optional)
+
+                        // Popcorn Skeletons
+                        "Grinning Fetish",  // Earendel's Embrace (x2) (obtained 1/2)
+                        "Compound Spiked Shield",  // Maligaro's Lense (optional)
+                        "Bone Armour",  // Bloodbond (optional?)
+                        "Soldier Boots",  // Alberon's Warpath
+                        "Embroidered Gloves",  // Vixen's Entrapment
+
+                        // Whispering Ice CI Elequisitor
+                        "Vile Staff",  // The Whispering Ice (required!)
+                        "Onyx Amulet",  // Astramentis
+                        "Leather Belt",  // Cyclopean Coil
+                        "Cobalt Jewel",  // Fertile Mind (x2)
+                        "Crimson Jewel",  // Brute Force Solution
+                        "Crimson Jewel",  // Izaro's Turmoil
+                        "Viridian Jewel",  // Pure Talent
+
+                        // Mjolner Discharge
+                        "Gavel",  // Mjölner
+                        "Conquest Chainmail",  // Kingsguard
+                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
+                        "Diamond Ring",  // Romira's Banquet
+                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
+                        "Viridian Jewel",  // The Golden Rule
+                    };
+                    break;
+                case "Synthesis":
+                    chanceItems = new List<string>
+                    {
+                        // Toasters HC Occultist Support – 7 Auras + 4 Curses
+                        // https://www.pathofexile.com/forum/view-thread/2126677
+                        "Lacquered Garb",  // Victario's Influence (required)
+                        "Archon Kite Shield",  // Prism Guardian (required)
+                        "Prophet Crown",  // The Broken Crown (required)
+                        "Paua Ring",  // Doedre’s Damning
+                        "Onyx Amulet",  // Impresence
+                        "War Hammer",  // Brightbeak (optional)
+                        "Stealth Boots",  // Sin Trek (optional)
+                        "Samite Gloves",  // Kalista's Grace (optional)
+                    };
+                    break;
+                case "SSF Betrayal":
+                    chanceItems = new List<string>
+                    {
+                        "Ranger Bow",  // Null's Inclination (required)
+                        "Lacquered Garb",  // Victario's Influence (required)
+                        "Prophet Crown",  // Speaker's Wreath (required)
+                        // "Riveted Gloves",  // Command of the Pit (drop-only from a delve boss?)
+
+                        // Enki's Arc Witch
+                        // TODO: Have to check what's actually required or
+                        // recommended.  Lots of dense information in the guide.
+                        "Sadist Garb",  // Inpulsa's Broken Heart
+
+                        // Lightning Tendrils CwC Arc
+                        // "Harlequin Mask",  // Mind of the Council (only from Unbearable Whispers prophecy chain).
+                        "Sadist Garb",  // Inpulsa's Broken Heart
+                        "Lapis Amulet",  // Choir of the Storm (optional)
+
+                        // Incinerate/Fireball Ignite Elementalist
+                        "Lathi",  // The Searing Touch
+                        "Samite Helmet",  // Hrimnor's Resolve
+                        "Glorious Plate",  // Kaom's Heart
+                        "Ruby Ring",  // Emberwake (x2)
+                        "Onyx Amulet",  // Impresence
+                        "Bismuth Flask",  // The Wise Oak
+                        "Viridian Jewel",  // Grand Spectrum (x3)
+
+                        // Whispering Ice CI Elequisitor
+                        // "Vile Staff",  // The Whispering Ice (required!) (obtained)
+                        "Onyx Amulet",  // Astramentis
+                        "Leather Belt",  // Cyclopean Coil
+                        "Cobalt Jewel",  // Fertile Mind (x2)
+                        "Crimson Jewel",  // Brute Force Solution
+                        "Crimson Jewel",  // Izaro's Turmoil
+                        "Viridian Jewel",  // Pure Talent
+
+                        // Mjolner Discharge
+                        "Gavel",  // Mjölner
+                        // "Conquest Chainmail",  // Kingsguard (obtained)
+                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
+                        "Diamond Ring",  // Romira's Banquet
+                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
+                        "Viridian Jewel",  // The Golden Rule
+                    };
+                    break;
+                case "SSF Delve":
+                    chanceItems = new List<string>
+                    {
+                        // Triple Herald Blade Vortex Elementalist
+                        "Sadist Garb",  // Inpulsa's Broken Heart
+                        // "Silken Hood",  // Starkonja's Head [obtained]
+                        "Goathide Gloves",  // Hrimsorrow
+                        // "Amethyst Flask",  // Atziri's Promise (can not be chanced)
+                        "Sapphire Flask",  // Taste of Hate
+
+                        // Enki's Arc Witch
+                        // TODO: Have to check what's actually required or
+                        // recommended.  Lots of dense information in the guide.
+
+                        // Whispering Ice CI Elequisitor
+                        // "Vile Staff",  // The Whispering Ice (required!) [obtained]
+                        "Onyx Amulet",  // Astramentis
+                        "Leather Belt",  // Cyclopean Coil
+                        "Cobalt Jewel",  // Fertile Mind (x2)
+                        "Crimson Jewel",  // Brute Force Solution
+                        "Crimson Jewel",  // Izaro's Turmoil
+                        "Viridian Jewel",  // Pure Talent
+
+                        // Mjolner Discharge
+                        "Gavel",  // Mjölner
+                        // "Conquest Chainmail",  // Kingsguard [obtained]
+                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
+                        "Diamond Ring",  // Romira's Banquet
+                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
+                        "Viridian Jewel",  // The Golden Rule
+                    };
+                    break;
+                case "SSF Incursion":
+                    chanceItems = new List<string>
+                    {
+                        // Mjolner Discharge
+                        "Gavel",  // Mjölner
+                        "Conquest Chainmail",  // Kingsguard
+                        // "Titan Greaves",  // The Red Trail (Breach exclusive; upgrade from The Infinite Pursuit)
+                        "Diamond Ring",  // Romira's Banquet
+                        // "Agate Amulet",  // Voll's Devotion (Anarchy/Onslaught exclusive)
+                        "Viridian Jewel",  // The Golden Rule
+
+                        // Elemental Wander
+                        "Tarnished Spirit Shield",  // Brinerot Flag (optional)
+                        "Destiny Leather",  // Queen of the Forest
+                        "Ursine Pelt",  // Rat's Nest
+                        "Topaz Flask",  // Vessel of Vinktar
+                        "Ruby Flask",  // Dying Sun
+                        "Bismuth Flask",  // The Wise Oak
+                        "Viridian Jewel",  // Static Electricity
+                        "Cobalt Jewel",  // Conqueror's Potency
+
+                        // CI Caustic Arrow
+                        "Spike-Point Arrow Quiver",  // Soul Strike
+                        "Onyx Amulet",  // Impresence
+                        "Stibnite Flask",  // Witchfire Brew
+                        "Ruby Flask",  // Dying Sun
+
+                        // Golemancer
+                        "Prismatic Jewel",  // The Anima Stone (also from vendor recipe using other uniques)
+                        "Cobalt Jewel",  // Primordial Harmony (x9)
+                        "Crimson Jewel",  // Primordial Might
+                        "Viridian Jewel",  // Primordial Eminence (x1, for The Anima Stone recipe)
+                        "Rock Breaker",  // Clayshaper (0/2 obtained)
+                        "Vaal Mask",  // The Vertex
+                        // "Unset Ring",  // Redblade Band (Warbands exclusive)
+                        // "Full Wyrmscale",  // Belly of the Beast (not needed in this build)
+
+                        // SRS/Zombies Necromancer
+                        "Elegant Ringmail",  // Geofri's Sanctuary
+                        "Crusader Gloves",  // Shaper's Touch
+                        "Close Helmet",  // The Baron
+                        "Void Sceptre",  // Mon'tregul's Grasp
+                        "Onyx Amulet",  // Astramentis
+                        "Soldier Boots",  // Alberon's Warpath
+                        "Cobalt Jewel",  // Violent Dead (x2)
+                        "Crimson Jewel",  // Efficient Training (x3)
+                        "Crimson Jewel",  // Brawn (x2-3)
+                    };
+                    break;
+                case "SSF Standard":
+                    chanceItems = new List<string>
+                    {
+                        // SR/RF Totems
+                        "Spidersilk Robe",  // Soul Mantle
+                        // "Vaal Sceptre",  // Doryani's Catalyst (can not be chanced)
+                        "Pinnacle Tower Shield",  // Lioneye's Remorse
+                        // "Samite Helmet",  // Hrimnor's Resolve (obtained)
+                        "Topaz Ring",  // Kikazaru (2x)
+                        "Crimson Jewel",  // Spire of Stone
+                        "Viridian Jewel",  // Self-Flagellation
+
+                        // Elemental Wander
+                        "Tarnished Spirit Shield",  // Brinerot Flag (optional)
+                        // "Destiny Leather",  // Queen of the Forest (obtained)
+                        "Ursine Pelt",  // Rat's Nest
+                        "Topaz Flask",  // Vessel of Vinktar
+                        "Ruby Flask",  // Dying Sun
+                        // "Bismuth Flsk",  // The Wise Oak (obtained)
+                        "Viridian Jewel",  // Static Electricity
+                        "Cobalt Jewel",  // Conqueror's Potency
+                    };
+                    break;
+                case "SSF Bestiary":
+                    chanceItems = new List<string>
+                    {
+                        // Frost Wind Ascendant
+                        "Imperial Skean",  // White Wind
+                        "Nubuck Gloves",  // Oskarm
+                        "Full Wyrmscale",  // Belly of the Beast
+
+                        // Magma Orb MoM Caster
+                        "Paua Ring",  // Doedre's Damning
+                        "Blue Pearl Amulet",  // Gloomfang
+                        // "Amethyst Flask",  // Atziri's Promise (can not be chanced)
+                        // "Cobalt Jewel",  // Inevitability (2/2 obtained)
+
+                        // SRS/Zombies Necromancer
+                        "Spidersilk Robe",  // The Covenant
+                        // "Close Helmet",  // The Baron (obtained)
+                        "Void Sceptre",  // Mon'tregul's Grasp
+                        "Onyx Amulet",  // Astramentis
+                        "Colossal Tower Shield",  // Ahn's Heritage
+                        "Crimson Jewel",  // Fragility (x2)
+                        "Soldier Boots",  // Alberon's Warpath
+                        "Crimson Jewel",  // Efficient Training (x2)
+                        "Cobalt Jewel",  // Violent Dead (x2)
+                        "Laminated Kite Shield",  // Victario's Charity (Necromantic Aegis variant)
+                        "Rawhide Tower Shield",  // Lycosidae (Necromantic Aegis variant)
+                    };
+                    break;
+                case "Bestiary":
+                    chanceItems = new List<string>
+                    {
+                        // Golemancer
+                        "Prismatic Jewel",  // The Anima Stone (also from vendor recipe using other uniques)
+                        "Cobalt Jewel",  // Primordial Harmony (x9)
+                        "Crimson Jewel",  // Primordial Might
+                        "Viridian Jewel",  // Primordial Eminence (x1, for The Anima Stone recipe)
+                        "Rock Breaker",  // Clayshaper (1/2 obtained)
+                        "Secutor Helm",  // Skullhead (expensive alternative)
+                        // "Unset Ring",  // Redblade Band (Warbands exclusive)
+                        "Full Wyrmscale",  // Belly of the Beast (very much optional)
+                    };
+                    break;
+                default:
+                    chanceItems = new List<string>();
+                    break;
+            }
+            chanceItems = chanceItems.Distinct().ToList();
+
+            StringBuilder chanceItemsFilter = new StringBuilder();
+            if (chanceItems.Count() > 0)
+            {
+                StringBuilder baseTypeLine = new StringBuilder();
+                foreach (var item in chanceItems)
+                {
+                    baseTypeLine.AppendFormat(" \"{0}\"", item);
+                }
+                chanceItemsFilter.AppendFormat(@"
+
+Show # $Chancing B-T1-Chancing %D4
+	BaseType{0}
+	Rarity Normal
+	Quality = 0
+	ElderItem False
+	ShaperItem False
+	Corrupted False
+	SetFontSize 38
+	SetTextColor 255 255 255 255         # TEXTCOLOR:	 Normal Items: Strong Highlight
+	SetBorderColor 0 210 0 210           # BORDERCOLOR:	 T1 Chancing
+	PlayAlertSound 7 300                 # DROPSOUND:	 T1 chancing items
+", baseTypeLine.ToString());
+            }
+
+            const string chancingBasesSearchString = @"#   [0710] Chancing items
+#------------------------------------
+# You can add your own items here. The items in this section have a dropsound";
+            var matchLocation = itemFilterText.IndexOf(chancingBasesSearchString);
+            if (matchLocation < 0)
+            {
+                matchLocation = 0;
+            }
+            return itemFilterText.Insert(matchLocation + chancingBasesSearchString.Length,
+                chanceItemsFilter.ToString());
+        }
+    }
+}

--- a/Procurement/ViewModel/RecipeResultViewModel.cs
+++ b/Procurement/ViewModel/RecipeResultViewModel.cs
@@ -68,6 +68,8 @@ namespace Procurement.ViewModel
             Results = manager.Run(itemsByTab);
             if (Results.Count > 0)
                 SelectedItem = Results.Values.First().First().MatchedItems[0];
+
+            LootFilterUpdater.UpdateLootFilter();
         }
 
         void ApplicationState_LeagueChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/Procurement/ViewModel/RecipeResultViewModel.cs
+++ b/Procurement/ViewModel/RecipeResultViewModel.cs
@@ -69,7 +69,7 @@ namespace Procurement.ViewModel
             if (Results.Count > 0)
                 SelectedItem = Results.Values.First().First().MatchedItems[0];
 
-            LootFilterUpdater.UpdateLootFilter();
+            ItemFilterUpdater.UpdateLootFilters();
         }
 
         void ApplicationState_LeagueChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
This PR adds limited support for updating loot filters after recreating the list of recipes.  There are two types of loot filters that can be added: items that are missing for partially-completed same-base-type recipes (that is, having a Normal, Magic, and Rare item of the same base type), with a variant for near-20% quality bases; and items that are chancing bases for builds in the current league.

The configuration for updating the item filters is managed by a Protocol Buffer `.proto` file.  Support has been added for Visual Studio to automatically compile the `.proto` file into C# classes that are virtually immediately recognized by Visual Studio's error-checking- and intelligence-generating systems.  Procurement reads and writes the actual configuration from and to a json file.

Closes #821.