### PR TITLE
Automatically refresh used tab when log file changes

### DIFF
--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Controls\FragmentStashTab.xaml.cs">
       <DependentUpon>FragmentStashTab.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utility\ClientLogFileWatcher.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FossilFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FracturedItemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\IncubatorFilter.cs" />

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Controls\FragmentStashTab.xaml.cs">
       <DependentUpon>FragmentStashTab.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utility\ClientLogFileEventArgs.cs" />
     <Compile Include="Utility\ClientLogFileWatcher.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FossilFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FracturedItemFilter.cs" />

--- a/Procurement/Utility/ClientLogFileEventArgs.cs
+++ b/Procurement/Utility/ClientLogFileEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Procurement.Utility
+{
+    public class ClientLogFileEventArgs : EventArgs
+    {
+        public DateTime EventDateTime { get; private set; }
+        public long EventTimestamp { get; private set; }
+        public string LocationEntered { get; private set; }
+
+        public ClientLogFileEventArgs(DateTime eventDateTime, long eventTimestamp, string locationEntered)
+        {
+            EventDateTime = eventDateTime;
+            EventTimestamp = eventTimestamp;
+            LocationEntered = locationEntered;
+        }
+    }
+}

--- a/Procurement/Utility/ClientLogFileWatcher.cs
+++ b/Procurement/Utility/ClientLogFileWatcher.cs
@@ -1,29 +1,12 @@
 ﻿using POEApi.Infrastructure;
 using POEApi.Model;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Procurement.Utility
 {
-    public class ClientLogFileEventArgs : EventArgs
-    {
-        public DateTime EventDateTime { get; private set; }
-        public long EventTimestamp { get; private set; }
-        public string LocationEntered { get; private set; }
-
-        public ClientLogFileEventArgs(DateTime eventDateTime, long eventTimestamp, string locationEntered)
-        {
-            EventDateTime = eventDateTime;
-            EventTimestamp = eventTimestamp;
-            LocationEntered = locationEntered;
-        }
-    }
-
     class ClientLogFileWatcher
     {
         private static ClientLogFileWatcher _instance;

--- a/Procurement/Utility/ClientLogFileWatcher.cs
+++ b/Procurement/Utility/ClientLogFileWatcher.cs
@@ -1,0 +1,179 @@
+﻿using POEApi.Infrastructure;
+using POEApi.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Procurement.Utility
+{
+    public class ClientLogFileEventArgs : EventArgs
+    {
+        public DateTime EventDateTime { get; private set; }
+        public long EventTimestamp { get; private set; }
+        public string LocationEntered { get; private set; }
+
+        public ClientLogFileEventArgs(DateTime eventDateTime, long eventTimestamp, string locationEntered)
+        {
+            EventDateTime = eventDateTime;
+            EventTimestamp = eventTimestamp;
+            LocationEntered = locationEntered;
+        }
+    }
+
+    class ClientLogFileWatcher
+    {
+        private static ClientLogFileWatcher _instance;
+        public static ClientLogFileWatcher Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = new ClientLogFileWatcher();
+
+                return _instance;
+            }
+        }
+
+        protected static System.IO.FileSystemWatcher FileWatcher
+        {
+            get;
+            private set;
+        }
+
+        public delegate void ClientLogFileEventHandler(ClientLogFileWatcher sender, ClientLogFileEventArgs e);
+        public static event ClientLogFileEventHandler ClientLogFileChanged;
+
+        public DateTime LastDateTimeSeen
+        {
+            get;
+            protected set;
+        }
+
+        public long LastTimestampSeen
+        {
+            get;
+            protected set;
+        }
+
+        public long LastFileSizeSeen
+        {
+            get;
+            protected set;
+        }
+
+        protected System.Timers.Timer PollingTimer
+        {
+            get;
+            set;
+        }
+
+        protected void Initialize()
+        {
+            if (!Settings.UserSettings.Keys.Contains("ClientLogFileLocation"))
+                return;
+            string fullFilePath = Settings.UserSettings["ClientLogFileLocation"];
+
+            FileWatcher = new System.IO.FileSystemWatcher();
+            FileWatcher.Path = System.IO.Path.GetDirectoryName(fullFilePath);
+            FileWatcher.Filter = System.IO.Path.GetFileName(fullFilePath);
+            FileWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.LastAccess;
+
+            FileWatcher.Changed += OnFileChanged;
+
+            PollingTimer = new System.Timers.Timer();
+            PollingTimer.Elapsed += (s, e) => { ReadClientLogFile(); };
+            PollingTimer.Interval = 30000;  // 30 seconds
+        }
+
+        internal void Start()
+        {
+            if (!Settings.UserSettings.Keys.Contains("EnableClientLogFileMonitoring"))
+                return;
+            var enabled = Convert.ToBoolean(Settings.UserSettings["EnableClientLogFileMonitoring"]);
+            if (!enabled)
+                return;
+
+            if (FileWatcher == null)
+                Initialize();
+
+            FileWatcher.EnableRaisingEvents = true;
+
+            if (!PollingTimer.Enabled)
+                PollingTimer.Start();
+        }
+
+        internal void Stop()
+        {
+            if (FileWatcher != null)
+                FileWatcher.EnableRaisingEvents = false;
+
+            PollingTimer.Stop();
+        }
+
+        protected void ReadClientLogFile()
+        {
+            lock (Instance)
+            {
+                var rx = new Regex(
+                    @"(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) (\d+) [^ .]* \[.*\] : You have entered (.*).$",
+                    RegexOptions.Compiled);
+
+                try
+                {
+                    Stream stream = new FileStream(Settings.UserSettings["ClientLogFileLocation"], FileMode.Open,
+                        FileAccess.Read, FileShare.ReadWrite);
+                    using (var reader = new StreamReader(stream))
+                    {
+                        if (reader.BaseStream.Length <= Instance.LastFileSizeSeen)
+                        {
+                            return;
+                        }
+
+                        reader.BaseStream.Seek(Instance.LastFileSizeSeen, System.IO.SeekOrigin.Begin);
+                        string line;
+                        DateTime eventTime = Instance.LastDateTimeSeen;
+                        long eventTimestamp = Instance.LastTimestampSeen;
+                        string location;
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            Match match = rx.Match(line);
+                            if (!match.Success)
+                                continue;
+
+                            eventTime = DateTime.ParseExact(match.Groups[1].Value, "yyyy/MM/dd HH:mm:ss",
+                                System.Globalization.CultureInfo.InvariantCulture);
+                            long.TryParse(match.Groups[2].Value, out eventTimestamp);
+                            location = match.Groups[3].Value;
+
+                            if ((DateTime.Now - eventTime).TotalSeconds > 600 ||
+                                eventTime < Instance.LastDateTimeSeen)
+                            {
+                                continue;
+                            }
+
+                            ClientLogFileChanged?.Invoke(Instance,
+                                new ClientLogFileEventArgs(eventTime, eventTimestamp, location));
+                        }
+
+                        Instance.LastDateTimeSeen = eventTime;
+                        Instance.LastTimestampSeen = eventTimestamp;
+                        Instance.LastFileSizeSeen = reader.BaseStream.Length;
+                    }
+                }
+                catch (System.IO.IOException ex)
+                {
+                    Logger.Log(string.Format("Failed to open config log file: {0}", ex.ToString()));
+                }
+            }
+        }
+
+        protected static void OnFileChanged(object source, System.IO.FileSystemEventArgs e)
+        {
+            Instance.ReadClientLogFile();
+        }
+    }
+}

--- a/Procurement/Utility/ClientLogFileWatcher.cs
+++ b/Procurement/Utility/ClientLogFileWatcher.cs
@@ -82,6 +82,8 @@ namespace Procurement.Utility
             if (!Settings.UserSettings.Keys.Contains("ClientLogFileLocation"))
                 return;
             string fullFilePath = Settings.UserSettings["ClientLogFileLocation"];
+            if (string.IsNullOrWhiteSpace(fullFilePath))
+                return;
 
             FileWatcher = new System.IO.FileSystemWatcher();
             FileWatcher.Path = System.IO.Path.GetDirectoryName(fullFilePath);

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -185,6 +185,8 @@ namespace Procurement.ViewModel
 
                 ApplicationState.SetDefaults();
 
+                ClientLogFileWatcher.Instance.Start();
+
                 if (!offline)
                 {
                     _statusController.DisplayMessage("\nDone!");

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -30,6 +30,8 @@ namespace Procurement.ViewModel
         private bool currencyDistributionUsesCount;
         private string filter;
 
+        private const string _enableTabRefreshOnLocationChangedConfigName = "EnableTabRefreshOnLocationChanged";
+
         public string Filter
         {
             get { return filter; }
@@ -180,10 +182,11 @@ namespace Procurement.ViewModel
             else
                 configuredOrbType = (OrbType)Enum.Parse(typeof(OrbType), currencyDistributionMetric);
 
-            if (Settings.UserSettings.Keys.Contains("EnableTabRefreshOnLocationChanged"))
+            if (Settings.UserSettings.Keys.Contains(_enableTabRefreshOnLocationChangedConfigName))
             {
                 var enabled = false;
-                if (bool.TryParse(Settings.UserSettings["EnableTabRefreshOnLocationChanged"], out enabled) && enabled)
+                if (bool.TryParse(Settings.UserSettings[_enableTabRefreshOnLocationChangedConfigName], out enabled)
+                    && enabled)
                 {
                     ClientLogFileWatcher.ClientLogFileChanged -= OnClientLogFileChanged;
                     ClientLogFileWatcher.ClientLogFileChanged += OnClientLogFileChanged;

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -136,6 +136,11 @@ namespace Procurement.ViewModel
         public static DateTime LastAutomaticRefresh { get; protected set; }
         public void OnClientLogFileChanged(object sender, ClientLogFileEventArgs e)
         {
+            // All actions currently taken when the log file changes relate to refreshing staash tabs.  This checks
+            // first that we are logged in, and quits early if we are not.
+            if (!LoggedIn)
+                return;
+
             lock (this)
             {
                 if ((DateTime.Now - LastAutomaticRefresh).TotalSeconds <= 120)

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -175,8 +175,15 @@ namespace Procurement.ViewModel
             else
                 configuredOrbType = (OrbType)Enum.Parse(typeof(OrbType), currencyDistributionMetric);
 
-            ClientLogFileWatcher.ClientLogFileChanged -= OnClientLogFileChanged;
-            ClientLogFileWatcher.ClientLogFileChanged += OnClientLogFileChanged;
+            if (Settings.UserSettings.Keys.Contains("EnableTabRefreshOnLocationChanged"))
+            {
+                var enabled = false;
+                if (bool.TryParse(Settings.UserSettings["EnableTabRefreshOnLocationChanged"], out enabled) && enabled)
+                {
+                    ClientLogFileWatcher.ClientLogFileChanged -= OnClientLogFileChanged;
+                    ClientLogFileWatcher.ClientLogFileChanged += OnClientLogFileChanged;
+                }
+            }
         }
 
         private void getAvailableItems()


### PR DESCRIPTION
This PR accomplishes two things:
1) Add a class that monitors the client log file for changes, and reads new content when it has.  When it finds log messages indicating the player's character has changed locations, it triggers an event.
2) Add a handler for this event that refreshes all the user's used tabs.  This only happens at most ever two minutes.

Both of these behaviors are disabled by default.  The former is disabled when the config value `ClientLogFileLocation`, which should point to the log file, is missing or empty; or if the config value `EnableClientLogFileMonitoring` is missing or false.  The latter is disabled when the config value `EnableTabRefreshOnLocationChanged` is missing or false.