### PR TITLE
Fix some memory leaks from recreating UserControls

### DIFF
--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Controls\FragmentStashTab.xaml.cs">
       <DependentUpon>FragmentStashTab.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utility\ClientLogFileWatcher.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FossilFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FracturedItemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\IncubatorFilter.cs" />

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Controls\FragmentStashTab.xaml.cs">
       <DependentUpon>FragmentStashTab.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utility\ClientLogFileEventArgs.cs" />
     <Compile Include="Utility\ClientLogFileWatcher.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FossilFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\FracturedItemFilter.cs" />

--- a/Procurement/Utility/ClientLogFileEventArgs.cs
+++ b/Procurement/Utility/ClientLogFileEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Procurement.Utility
+{
+    public class ClientLogFileEventArgs : EventArgs
+    {
+        public DateTime EventDateTime { get; private set; }
+        public long EventTimestamp { get; private set; }
+        public string LocationEntered { get; private set; }
+
+        public ClientLogFileEventArgs(DateTime eventDateTime, long eventTimestamp, string locationEntered)
+        {
+            EventDateTime = eventDateTime;
+            EventTimestamp = eventTimestamp;
+            LocationEntered = locationEntered;
+        }
+    }
+}

--- a/Procurement/Utility/ClientLogFileWatcher.cs
+++ b/Procurement/Utility/ClientLogFileWatcher.cs
@@ -1,29 +1,12 @@
 ﻿using POEApi.Infrastructure;
 using POEApi.Model;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Procurement.Utility
 {
-    public class ClientLogFileEventArgs : EventArgs
-    {
-        public DateTime EventDateTime { get; private set; }
-        public long EventTimestamp { get; private set; }
-        public string LocationEntered { get; private set; }
-
-        public ClientLogFileEventArgs(DateTime eventDateTime, long eventTimestamp, string locationEntered)
-        {
-            EventDateTime = eventDateTime;
-            EventTimestamp = eventTimestamp;
-            LocationEntered = locationEntered;
-        }
-    }
-
     class ClientLogFileWatcher
     {
         private static ClientLogFileWatcher _instance;

--- a/Procurement/Utility/ClientLogFileWatcher.cs
+++ b/Procurement/Utility/ClientLogFileWatcher.cs
@@ -1,0 +1,179 @@
+﻿using POEApi.Infrastructure;
+using POEApi.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Procurement.Utility
+{
+    public class ClientLogFileEventArgs : EventArgs
+    {
+        public DateTime EventDateTime { get; private set; }
+        public long EventTimestamp { get; private set; }
+        public string LocationEntered { get; private set; }
+
+        public ClientLogFileEventArgs(DateTime eventDateTime, long eventTimestamp, string locationEntered)
+        {
+            EventDateTime = eventDateTime;
+            EventTimestamp = eventTimestamp;
+            LocationEntered = locationEntered;
+        }
+    }
+
+    class ClientLogFileWatcher
+    {
+        private static ClientLogFileWatcher _instance;
+        public static ClientLogFileWatcher Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = new ClientLogFileWatcher();
+
+                return _instance;
+            }
+        }
+
+        protected static System.IO.FileSystemWatcher FileWatcher
+        {
+            get;
+            private set;
+        }
+
+        public delegate void ClientLogFileEventHandler(ClientLogFileWatcher sender, ClientLogFileEventArgs e);
+        public static event ClientLogFileEventHandler ClientLogFileChanged;
+
+        public DateTime LastDateTimeSeen
+        {
+            get;
+            protected set;
+        }
+
+        public long LastTimestampSeen
+        {
+            get;
+            protected set;
+        }
+
+        public long LastFileSizeSeen
+        {
+            get;
+            protected set;
+        }
+
+        protected System.Timers.Timer PollingTimer
+        {
+            get;
+            set;
+        }
+
+        protected void Initialize()
+        {
+            if (!Settings.UserSettings.Keys.Contains("ClientLogFileLocation"))
+                return;
+            string fullFilePath = Settings.UserSettings["ClientLogFileLocation"];
+
+            FileWatcher = new System.IO.FileSystemWatcher();
+            FileWatcher.Path = System.IO.Path.GetDirectoryName(fullFilePath);
+            FileWatcher.Filter = System.IO.Path.GetFileName(fullFilePath);
+            FileWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.LastAccess;
+
+            FileWatcher.Changed += OnFileChanged;
+
+            PollingTimer = new System.Timers.Timer();
+            PollingTimer.Elapsed += (s, e) => { ReadClientLogFile(); };
+            PollingTimer.Interval = 30000;  // 30 seconds
+        }
+
+        internal void Start()
+        {
+            if (!Settings.UserSettings.Keys.Contains("EnableClientLogFileMonitoring"))
+                return;
+            var enabled = Convert.ToBoolean(Settings.UserSettings["EnableClientLogFileMonitoring"]);
+            if (!enabled)
+                return;
+
+            if (FileWatcher == null)
+                Initialize();
+
+            FileWatcher.EnableRaisingEvents = true;
+
+            if (!PollingTimer.Enabled)
+                PollingTimer.Start();
+        }
+
+        internal void Stop()
+        {
+            if (FileWatcher != null)
+                FileWatcher.EnableRaisingEvents = false;
+
+            PollingTimer.Stop();
+        }
+
+        protected void ReadClientLogFile()
+        {
+            lock (Instance)
+            {
+                var rx = new Regex(
+                    @"(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) (\d+) [^ .]* \[.*\] : You have entered (.*).$",
+                    RegexOptions.Compiled);
+
+                try
+                {
+                    Stream stream = new FileStream(Settings.UserSettings["ClientLogFileLocation"], FileMode.Open,
+                        FileAccess.Read, FileShare.ReadWrite);
+                    using (var reader = new StreamReader(stream))
+                    {
+                        if (reader.BaseStream.Length <= Instance.LastFileSizeSeen)
+                        {
+                            return;
+                        }
+
+                        reader.BaseStream.Seek(Instance.LastFileSizeSeen, System.IO.SeekOrigin.Begin);
+                        string line;
+                        DateTime eventTime = Instance.LastDateTimeSeen;
+                        long eventTimestamp = Instance.LastTimestampSeen;
+                        string location;
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            Match match = rx.Match(line);
+                            if (!match.Success)
+                                continue;
+
+                            eventTime = DateTime.ParseExact(match.Groups[1].Value, "yyyy/MM/dd HH:mm:ss",
+                                System.Globalization.CultureInfo.InvariantCulture);
+                            long.TryParse(match.Groups[2].Value, out eventTimestamp);
+                            location = match.Groups[3].Value;
+
+                            if ((DateTime.Now - eventTime).TotalSeconds > 600 ||
+                                eventTime < Instance.LastDateTimeSeen)
+                            {
+                                continue;
+                            }
+
+                            ClientLogFileChanged?.Invoke(Instance,
+                                new ClientLogFileEventArgs(eventTime, eventTimestamp, location));
+                        }
+
+                        Instance.LastDateTimeSeen = eventTime;
+                        Instance.LastTimestampSeen = eventTimestamp;
+                        Instance.LastFileSizeSeen = reader.BaseStream.Length;
+                    }
+                }
+                catch (System.IO.IOException ex)
+                {
+                    Logger.Log(string.Format("Failed to open config log file: {0}", ex.ToString()));
+                }
+            }
+        }
+
+        protected static void OnFileChanged(object source, System.IO.FileSystemEventArgs e)
+        {
+            Instance.ReadClientLogFile();
+        }
+    }
+}

--- a/Procurement/Utility/ClientLogFileWatcher.cs
+++ b/Procurement/Utility/ClientLogFileWatcher.cs
@@ -82,6 +82,8 @@ namespace Procurement.Utility
             if (!Settings.UserSettings.Keys.Contains("ClientLogFileLocation"))
                 return;
             string fullFilePath = Settings.UserSettings["ClientLogFileLocation"];
+            if (string.IsNullOrWhiteSpace(fullFilePath))
+                return;
 
             FileWatcher = new System.IO.FileSystemWatcher();
             FileWatcher.Path = System.IO.Path.GetDirectoryName(fullFilePath);

--- a/Procurement/View/RecipeView.xaml.cs
+++ b/Procurement/View/RecipeView.xaml.cs
@@ -30,5 +30,10 @@ namespace Procurement.View
         {
             get { return this.ViewContent; }
         }
+
+        public void RefreshRecipes()
+        {
+            (this.DataContext as RecipeResultViewModel).RefreshRecipes();
+        }
     }
 }

--- a/Procurement/View/RefreshView.xaml.cs
+++ b/Procurement/View/RefreshView.xaml.cs
@@ -10,13 +10,18 @@ using System.Windows.Controls;
 
 namespace Procurement.View
 {
-    public partial class RefreshView : UserControl
+    public partial class RefreshView : UserControl, IView
     {
         private StatusController statusController;
 
         public RefreshView()
         {
             InitializeComponent();
+        }
+
+        public new Grid Content
+        {
+            get { return this.ViewContent; }
         }
 
         public void RefreshAllTabs()
@@ -67,6 +72,7 @@ namespace Procurement.View
                     ScreenController.Instance.ReloadStash();
                     ScreenController.Instance.RefreshRecipeScreen();
                     ScreenController.Instance.UpdateTrading();
+                    statusController.Clear();
                 }
             });
         }

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -185,6 +185,8 @@ namespace Procurement.ViewModel
 
                 ApplicationState.SetDefaults();
 
+                ClientLogFileWatcher.Instance.Start();
+
                 if (!offline)
                 {
                     _statusController.DisplayMessage("\nDone!");

--- a/Procurement/ViewModel/RecipeResultViewModel.cs
+++ b/Procurement/ViewModel/RecipeResultViewModel.cs
@@ -39,7 +39,7 @@ namespace Procurement.ViewModel
         public RecipeResultViewModel()
         {
             manager = new RecipeManager();
-            ApplicationState.LeagueChanged += new System.ComponentModel.PropertyChangedEventHandler(ApplicationState_LeagueChanged);
+            ApplicationState.LeagueChanged += ApplicationState_LeagueChanged;
             updateResults();
         }
 
@@ -68,6 +68,11 @@ namespace Procurement.ViewModel
             Results = manager.Run(itemsByTab);
             if (Results.Count > 0)
                 SelectedItem = Results.Values.First().First().MatchedItems[0];
+        }
+
+        public void RefreshRecipes()
+        {
+            updateResults();
         }
 
         void ApplicationState_LeagueChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/Procurement/ViewModel/ScreenController.cs
+++ b/Procurement/ViewModel/ScreenController.cs
@@ -92,12 +92,8 @@ namespace Procurement.ViewModel
                 screens.Add(SETTINGS_VIEW, new SettingsView());
                 screens.Add(RECIPE_VIEW, null);
                 screens.Add(ABOUT_VIEW, new AboutView());
+                screens.Add(REFRESH_VIEW, new RefreshView());
             }));
-        }
-
-        public void InvalidateRecipeScreen()
-        {
-            screens[RECIPE_VIEW] = null;
         }
 
         public void RefreshRecipeScreen()
@@ -105,10 +101,13 @@ namespace Procurement.ViewModel
             Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,
                 new Action(() =>
                 {
-                    // TODO: Cause the RecipeResultsViewModel in the RecipeView to refresh its recipes, instead of
-                    // recreating the RecipeView object.  This could perhaps be done by triggering an event, or
-                    // reaching into the view/viewmodel and calling it directly (but that's probably very bad form).
-                    screens[RECIPE_VIEW] = new RecipeView();
+                    // TODO: See if we can find a more elegant way to refresh receipes, instead of calling a method on
+                    // the view.  Perhaps something with events?
+                    RecipeView view = screens[RECIPE_VIEW] as RecipeView;
+                    if (view == null)
+                        screens[RECIPE_VIEW] = new RecipeView();
+                    else
+                        view.RefreshRecipes();
                 }));
         }
 

--- a/Procurement/ViewModel/ScreenController.cs
+++ b/Procurement/ViewModel/ScreenController.cs
@@ -167,7 +167,6 @@ namespace Procurement.ViewModel
             Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal,
                 new Action(() =>
                 {
-                    screens[STASH_VIEW] = new StashView();
                     SelectedView = screens[STASH_VIEW] as UserControl;
                     ButtonsVisible = true;
                 }));

--- a/Procurement/ViewModel/ScreenController.cs
+++ b/Procurement/ViewModel/ScreenController.cs
@@ -34,6 +34,7 @@ namespace Procurement.ViewModel
         private const string INVENTORY_VIEW = "Inventory";
         private const string SETTINGS_VIEW = "Settings";
         private const string ABOUT_VIEW = "About";
+        private const string REFRESH_VIEW = "Refresh";
 
         public static ScreenController Instance = null;
         private UserControl _selectedView;
@@ -150,14 +151,14 @@ namespace Procurement.ViewModel
         public void LoadRefreshView()
         {
             ButtonsVisible = false;
-            SelectedView = new RefreshView();
+            SelectedView = screens[REFRESH_VIEW] as RefreshView;
             (SelectedView as RefreshView).RefreshAllTabs();
         }
 
         public void LoadRefreshViewUsed()
         {
             ButtonsVisible = false;
-            SelectedView = new RefreshView();
+            SelectedView = screens[REFRESH_VIEW] as RefreshView;
             (SelectedView as RefreshView).RefreshUsedTabs();
         }
 

--- a/Procurement/ViewModel/StatusController.cs
+++ b/Procurement/ViewModel/StatusController.cs
@@ -32,6 +32,16 @@ namespace Procurement.ViewModel
             CheckAccessAndInvoke(() => displayResult("ER", Brushes.Red));
         }
 
+        public void Clear()
+        {
+            CheckAccessAndInvoke(() => ClearInternal());
+        }
+
+        private void ClearInternal()
+        {
+            (statusBox.Document.Blocks.LastBlock as Paragraph).Inlines.Clear();
+        }
+
         public void DisplayMessage(string message)
         {
             CheckAccessAndInvoke((Action)delegate()

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -30,6 +30,8 @@ namespace Procurement.ViewModel
         private bool currencyDistributionUsesCount;
         private string filter;
 
+        private const string _enableTabRefreshOnLocationChangedConfigName = "EnableTabRefreshOnLocationChanged";
+
         public string Filter
         {
             get { return filter; }
@@ -180,10 +182,11 @@ namespace Procurement.ViewModel
             else
                 configuredOrbType = (OrbType)Enum.Parse(typeof(OrbType), currencyDistributionMetric);
 
-            if (Settings.UserSettings.Keys.Contains("EnableTabRefreshOnLocationChanged"))
+            if (Settings.UserSettings.Keys.Contains(_enableTabRefreshOnLocationChangedConfigName))
             {
                 var enabled = false;
-                if (bool.TryParse(Settings.UserSettings["EnableTabRefreshOnLocationChanged"], out enabled) && enabled)
+                if (bool.TryParse(Settings.UserSettings[_enableTabRefreshOnLocationChangedConfigName], out enabled)
+                    && enabled)
                 {
                     ClientLogFileWatcher.ClientLogFileChanged -= OnClientLogFileChanged;
                     ClientLogFileWatcher.ClientLogFileChanged += OnClientLogFileChanged;

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -126,13 +126,11 @@ namespace Procurement.ViewModel
         public ICommand RefreshCommand => new RelayCommand(x =>
         {
             ScreenController.Instance.LoadRefreshView();
-            ScreenController.Instance.InvalidateRecipeScreen();
         });
 
         public ICommand RefreshUsedCommand => new RelayCommand(x =>
         {
             ScreenController.Instance.LoadRefreshViewUsed();
-            ScreenController.Instance.InvalidateRecipeScreen();
         });
 
         public static DateTime LastAutomaticRefresh { get; protected set; }
@@ -155,7 +153,6 @@ namespace Procurement.ViewModel
                         if (ScreenController.Instance.ButtonsVisible)
                         {
                             ScreenController.Instance.LoadRefreshViewUsed();
-                            ScreenController.Instance.InvalidateRecipeScreen();
                         }
                     }));
             }

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -136,6 +136,11 @@ namespace Procurement.ViewModel
         public static DateTime LastAutomaticRefresh { get; protected set; }
         public void OnClientLogFileChanged(object sender, ClientLogFileEventArgs e)
         {
+            // All actions currently taken when the log file changes relate to refreshing staash tabs.  This checks
+            // first that we are logged in, and quits early if we are not.
+            if (!LoggedIn)
+                return;
+
             lock (this)
             {
                 if ((DateTime.Now - LastAutomaticRefresh).TotalSeconds <= 120)

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -179,6 +179,8 @@ namespace Procurement.ViewModel
             else
                 configuredOrbType = (OrbType)Enum.Parse(typeof(OrbType), currencyDistributionMetric);
 
+            ApplicationState.Model.StashLoading += ApplicationState_StashLoading;
+
             if (Settings.UserSettings.Keys.Contains(_enableTabRefreshOnLocationChangedConfigName))
             {
                 var enabled = false;
@@ -187,6 +189,23 @@ namespace Procurement.ViewModel
                 {
                     ClientLogFileWatcher.ClientLogFileChanged -= OnClientLogFileChanged;
                     ClientLogFileWatcher.ClientLogFileChanged += OnClientLogFileChanged;
+                }
+            }
+        }
+
+        private void ApplicationState_StashLoading(POEModel sender, POEApi.Model.Events.StashLoadedEventArgs e)
+        {
+            if (e.State != POEApi.Model.Events.POEEventState.AfterEvent)
+                return;
+
+            foreach (var tabAndContent in tabsAndContent)
+            {
+                if (tabAndContent.Index == e.StashID && tabAndContent.Stash is AbstractStashTabControl)
+                {
+                    // This tab has been refreshed.  We mark it as not ready, so it is refreshed the next time it is
+                    // selected.
+                    (tabAndContent.Stash as AbstractStashTabControl).Ready = false;
+                    break;
                 }
             }
         }

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -252,7 +252,6 @@ namespace Procurement.ViewModel
             var item = stashView.tabControl.SelectedItem as TabItem;
             selectedTab = item;
             Image i = item.Header as Image;
-            CroppedBitmap bm = (CroppedBitmap)i.Source;
             Tab tab = (Tab)i.Tag;
             item.Header = StashHelper.GenerateTabImage(tab, true);
         }
@@ -266,6 +265,8 @@ namespace Procurement.ViewModel
 
         void ApplicationState_LeagueChanged(object sender, PropertyChangedEventArgs e)
         {
+            tabsAndContent.Clear();
+
             getAvailableItems();
             stashView.tabControl.SelectionChanged -= new SelectionChangedEventHandler(tabControl_SelectionChanged);
             stashView.tabControl.Items.Clear();
@@ -339,9 +340,9 @@ namespace Procurement.ViewModel
 
         void stashView_Loaded(object sender, RoutedEventArgs e)
         {
+            var stash = ApplicationState.Stash[ApplicationState.CurrentLeague];
             for (var i = 1; i <= ApplicationState.Stash[ApplicationState.CurrentLeague].NumberOfTabs; i++)
             {
-                var stash = ApplicationState.Stash[ApplicationState.CurrentLeague];
                 var currentTab = stash.Tabs[i - 1];
 
                 var item = new TabItem

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -175,8 +175,15 @@ namespace Procurement.ViewModel
             else
                 configuredOrbType = (OrbType)Enum.Parse(typeof(OrbType), currencyDistributionMetric);
 
-            ClientLogFileWatcher.ClientLogFileChanged -= OnClientLogFileChanged;
-            ClientLogFileWatcher.ClientLogFileChanged += OnClientLogFileChanged;
+            if (Settings.UserSettings.Keys.Contains("EnableTabRefreshOnLocationChanged"))
+            {
+                var enabled = false;
+                if (bool.TryParse(Settings.UserSettings["EnableTabRefreshOnLocationChanged"], out enabled) && enabled)
+                {
+                    ClientLogFileWatcher.ClientLogFileChanged -= OnClientLogFileChanged;
+                    ClientLogFileWatcher.ClientLogFileChanged += OnClientLogFileChanged;
+                }
+            }
         }
 
         private void getAvailableItems()


### PR DESCRIPTION
**Note:** This PR slightly depends on the `log-file-monitor` branch (#1042), and includes it here in this PR as a base.  I'll rebase appropriately and make this PR ready for review when that PR has been merged.

Procurement recreates its stash and recipe views whenever they need updating.  This is inefficient and causes memory leaks (and this is readily apparent after automatically (and often) refreshing tabs).  This PR attempts to refresh those tabs instead of recreating them.  I believe I have addressed all the issues with reusing the same objects.

Note that the trading view is also recreated whenever tabs are refreshed; that is not addressed in this PR.