### PR TITLE
Hide item level if 0

### DIFF
--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -99,7 +99,7 @@
                         Text="{Binding ItemLevel}"
                         TextAlignment="Center"
                         TextWrapping="Wrap"
-                        Visibility="{Binding IsGear,
+                        Visibility="{Binding ItemLevel,
                                Converter={StaticResource bc},
                                ConverterParameter=CollapseWhenFalse}" />
 
@@ -107,7 +107,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding IsGear,
+                            Visibility="{Binding ItemLevel,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -197,7 +197,10 @@ namespace Procurement.ViewModel
         private void setGearProperties(Item item, Gear gear)
         {
             this.IsGear = true;
-            this.ItemLevel = string.Format("Item Level : {0}", item.ItemLevel);
+            if (item.ItemLevel > 0)
+            {
+                this.ItemLevel = string.Format("Item Level : {0}", item.ItemLevel);
+            }
             this.Requirements = gear.Requirements;
             this.ImplicitMods = gear.Implicitmods;
         }


### PR DESCRIPTION
hides item level: 0 from cards, map fragments and breachstones. closes #999

screenshot:
![ilvl](https://user-images.githubusercontent.com/47343000/64442575-b5049300-d0d8-11e9-8d12-2cabf97519a7.png)
