### PR TITLE
Update stat filters

### DIFF
--- a/POEApi.Model/Gear.cs
+++ b/POEApi.Model/Gear.cs
@@ -11,6 +11,9 @@ namespace POEApi.Model
         public List<Socket> Sockets { get; set; }
         public List<SocketableItem> SocketedItems { get; set; }
         public List<string> Implicitmods { get; set; }
+        public List<string> Craftedmods { get; set; }
+        public List<string> Fracturedmods { get; set; }
+        public List<string> Enchantmods { get; set; }
         public List<Requirement> Requirements { get; set; }
         public GearType GearType { get; set; }
         public string BaseType { get; set; }
@@ -23,6 +26,9 @@ namespace POEApi.Model
             Explicitmods = item.ExplicitMods;
             SocketedItems = GetSocketedItems(item);
             Implicitmods = item.ImplicitMods;
+            Craftedmods = item.CraftedMods;
+            Fracturedmods = item.FracturedMods;
+            Enchantmods = item.EnchantMods;
             Requirements = ProxyMapper.GetRequirements(item.Requirements);
             ItemType = Model.ItemType.Gear;
             GearType = GearTypeFactory.GetType(this);

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -181,7 +181,7 @@
     <Compile Include="Utility\StashHelper.cs" />
     <Compile Include="Utility\VersionChecker.cs" />
     <Compile Include="ViewModel\AdvancedSearchCategory.cs" />
-    <Compile Include="ViewModel\Filters\ForumExport\AccurayFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\AccuracyFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CraftedModFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CurrencyFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\DamageChaos.cs" />
@@ -236,6 +236,8 @@
     <Compile Include="ViewModel\DisplayModeStrategy\StringFormatStrategy.cs" />
     <Compile Include="ViewModel\DisplayModeStrategy\ValuesPlusNameStrategy.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\EnergyShieldFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\ArmourFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\EvasionFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\IncreasedPhysicalDamageFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\ManaFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\ManaRegenFilter.cs" />
@@ -266,6 +268,7 @@
     <Compile Include="ViewModel\Filters\ForumExport\ColdResistance.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CorruptedGemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CritChanceFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\CritMultiplierFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\GlobalCritMultiplierFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\CurseGemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\DamageCold.cs" />

--- a/Procurement/ViewModel/Filters/ForumExport/AccuracyFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/AccuracyFilter.cs
@@ -5,14 +5,14 @@ using System.Text;
 
 namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class AccurayFilter : StatFilter
+    internal class AccuracyFilter : StatFilter
     {
         public override FilterGroup Group
         {
             get { return FilterGroup.Attacks; }
         }
 
-        public AccurayFilter()
+        public AccuracyFilter()
             : base("Increased Accuracy", "Increased Accuracy", "Accuracy")
         { }
     }

--- a/Procurement/ViewModel/Filters/ForumExport/ArmourFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ArmourFilter.cs
@@ -5,10 +5,10 @@ using System.Text;
 
 namespace Procurement.ViewModel.Filters.ForumExport
 {
-    public class PercentEnergyShieldFilter : OrStatFilter
+    public class ArmourFilter : OrStatFilter
     {
-        public PercentEnergyShieldFilter()
-            : base("% Increased Energy Shield", "Items with % increased energy shield", "% increased maximum Energy Shield", "increased Global Defences")
+        public ArmourFilter()
+            : base("Armour", "Items with additional or increased Armour", "to Armour", "increased Armour", "increased Global Armour", "increased Global Defences")
         { }
 
         public override FilterGroup Group

--- a/Procurement/ViewModel/Filters/ForumExport/AttackSpeed.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/AttackSpeed.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class AttackSpeed : StatFilter
+    internal class AttackSpeed : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public AttackSpeed()
-            : base("Increased Attack Speed", "Increased Attack Speed", "Increased Attack Speed")
+            : base("Increased Attack Speed", "Increased Attack Speed", "increased Attack Speed", "increased Attack and Cast Speed", "increased Attack, Cast and Movement Speed")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/CastSpeed.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/CastSpeed.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class CastSpeed : StatFilter
+    internal class CastSpeed : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public CastSpeed()
-            : base("Increased Cast Speed", "Increased Cast Speed", "Increased Cast Speed")
+            : base("Increased Cast Speed", "Increased Cast Speed", "increased Cast Speed", "increased Attack and Cast Speed", "increased Attack, Cast and Movement Speed")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/ChaosResistance.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ChaosResistance.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters
 {
-    internal class ChaosResistance : StatFilter
+    internal class ChaosResistance : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public ChaosResistance()
-            : base("Chaos Resistance", "Chaos Resistance", "to Chaos Resistance")
+            : base("Chaos Resistance", "Chaos Resistance", "to Chaos Resistance", "to Fire and Chaos Resistances", "to Cold and Chaos Resistances", "to Lightning and Chaos Resistances")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/CharacterAttributeFilters.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/CharacterAttributeFilters.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    class StrengthFilter : StatFilter
+    class StrengthFilter : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,12 +8,12 @@
         }
 
         public StrengthFilter()
-            : base("Increased Strength", "Strength", "Strength")
+            : base("Increased Strength", "Increased Strength", "to Strength", "increased Strength", "to all Attributes", "increased Attributes")
         { }
     }
 
 
-    class IntelligenceFilter : StatFilter
+    class IntelligenceFilter : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -21,11 +21,11 @@
         }
 
         public IntelligenceFilter()
-            : base("Increased Intelligence", "Intelligence", "Intelligence")
+            : base("Increased Intelligence", "Increased Intelligence", "to Intelligence", "to Strength and Intelligence", "to Dexterity and Intelligence", "increased Intelligence", "to all Attributes", "increased Attributes")
         { }
     }
 
-    class DexterityFilter : StatFilter
+    class DexterityFilter : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -33,7 +33,7 @@
         }
 
         public DexterityFilter()
-            : base("Increased Dexterity", "Increased Dexterity", "Dexterity")
+            : base("Increased Dexterity", "Increased Dexterity", "to Dexterity", "to Strength and Dexterity", "increased Dexterity", "to all Attributes", "increased Attributes")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/ColdResistance.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ColdResistance.cs
@@ -8,7 +8,7 @@
         }
 
         public ColdResistance()
-            : base("Cold Resistance", "Cold Resistance", "to Cold Resistance", "to Fire and Cold Resistances", "to Cold and Lightning Resistances")
+            : base("Cold Resistance", "Cold Resistance", "to Cold Resistance", "to Fire and Cold Resistances", "to Cold and Lightning Resistances", "to Cold and Chaos Resistances", "to all Elemental Resistances")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/CritChanceFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/CritChanceFilter.cs
@@ -8,7 +8,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
     public class CritChanceFilter : ExplicitModBase
     {
         public CritChanceFilter()
-            : base("increased Critical Strike Chance")
+            : base("Critical Strike Chance")
         { }
 
         public override bool CanFormCategory
@@ -18,7 +18,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public override string Keyword
         {
-            get { return "Crit Chance"; }
+            get { return "Critical Strike Chance"; }
         }
 
         public override string Help

--- a/Procurement/ViewModel/Filters/ForumExport/CritMultiplierFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/CritMultiplierFilter.cs
@@ -5,10 +5,10 @@ using System.Text;
 
 namespace Procurement.ViewModel.Filters.ForumExport
 {
-    public class GlobalCritMultiplierFilter : ExplicitModBase
+    public class CritMultiplierFilter : ExplicitModBase
     {
-        public GlobalCritMultiplierFilter()
-            : base("Global Critical Strike Multiplier")
+        public CritMultiplierFilter()
+            : base("Critical Strike Multiplier")
         { }
 
         public override bool CanFormCategory
@@ -18,12 +18,12 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public override string Keyword
         {
-            get { return "Global Critical Strike Multiplier"; }
+            get { return "Critical Strike Multiplier"; }
         }
 
         public override string Help
         {
-            get { return "Items with additional Global Critical Strike Multiplier"; }
+            get { return "Items with additional Critical Strike Multiplier"; }
         }
 
         public override FilterGroup Group

--- a/Procurement/ViewModel/Filters/ForumExport/DamageChaos.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageChaos.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class DamageChaos : StatFilter
+    internal class DamageChaos : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public DamageChaos()
-            : base("Adds Chaos Damage", "Adds Chaos Damage", "Adds \\d+ to \\d+ Chaos Damage")
+            : base("Adds Chaos Damage", "Adds Chaos Damage", "Adds \\d+ to \\d+ Chaos Damage", "as Extra Chaos Damage")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/DamageCold.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageCold.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class DamageCold : StatFilter
+    internal class DamageCold : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public DamageCold()
-            : base("Adds Cold Damage", "Adds Cold Damage", "Adds \\d+ to \\d+ Cold Damage")
+            : base("Adds Cold Damage", "Adds Cold Damage", "Adds \\d+ to \\d+ Cold Damage", "as Extra Cold Damage", "as Extra Damage of each Element", "as Extra Damage of a random Element")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/DamageFire.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageFire.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class DamageFire : StatFilter
+    internal class DamageFire : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public DamageFire()
-            : base("Adds Fire Damage", "Adds Fire Damage", "Adds \\d+ to \\d+ Fire Damage")
+            : base("Adds Fire Damage", "Adds Fire Damage", "Adds \\d+ to \\d+ Fire Damage", "as Extra Fire Damage", "as Extra Damage of each Element", "as Extra Damage of a random Element")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/DamageLightning.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageLightning.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters.ForumExport
 {
-    internal class DamageLightning: StatFilter
+    internal class DamageLightning: OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public DamageLightning()
-            : base("Adds Lightning Damage", "Adds Lightning Damage", "Adds \\d+ to \\d+ Lightning Damage")
+            : base("Adds Lightning Damage", "Adds Lightning Damage", "Adds \\d+ to \\d+ Lightning Damage", "as Extra Lightning Damage", "as Extra Damage of each Element", "as Extra Damage of a random Element")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/DamageTriple.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/DamageTriple.cs
@@ -6,7 +6,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
 {
     internal class DamageTriple : IFilter
     {
-        private List<StatFilter> resistances;
+        private List<OrStatFilter> resistances;
 
         public FilterGroup Group
         {
@@ -15,7 +15,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public DamageTriple()
         {
-            resistances = new List<StatFilter>();
+            resistances = new List<OrStatFilter>();
             resistances.Add(new DamageCold());
             resistances.Add(new DamageFire());
             resistances.Add(new DamageLightning());

--- a/Procurement/ViewModel/Filters/ForumExport/EvasionFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/EvasionFilter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class EvasionFilter : OrStatFilter
+    {
+        public EvasionFilter()
+            : base("Evasion", "Items with additional or increased Evasion", "Evasion Rating", "increased Armour and Evasion", "increased Evasion and Energy Shield", "increased Armour, Evasion and Energy Shield", "increased Global Defences")
+        { }
+
+        public override FilterGroup Group
+        {
+            get { return FilterGroup.Default; }
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/ExplicitModBase.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ExplicitModBase.cs
@@ -14,12 +14,29 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public bool Applicable(Item item)
         {
-            if (item.Explicitmods == null || !(item is Gear))
+            Gear gear = item as Gear;
+            if (gear == null)
                 return false;
 
-            foreach (var mod in item.Explicitmods)
-                if (mod.Contains(keyword))
-                    return true;
+            if (gear.Explicitmods != null)
+                foreach (var mod in gear.Explicitmods)
+                    if (mod.Contains(keyword))
+                        return true;
+
+            if (gear.Fracturedmods != null)
+                foreach (var mod in gear.Fracturedmods)
+                    if (mod.Contains(keyword))
+                        return true;
+
+            if (gear.Craftedmods != null)
+                foreach (var mod in gear.Craftedmods)
+                    if (mod.Contains(keyword))
+                        return true;
+
+            if (gear.Enchantmods != null)
+                foreach (var mod in gear.Enchantmods)
+                    if (mod.Contains(keyword))
+                        return true;
 
             return false;
         }

--- a/Procurement/ViewModel/Filters/ForumExport/FireResistance.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/FireResistance.cs
@@ -8,7 +8,7 @@
         }
 
         public FireResistance()
-            : base("Fire Resistance", "Fire Resistance", "to Fire Resistance", "to Fire and Lightning Resistances", "to Fire and Cold Resistances")
+            : base("Fire Resistance", "Fire Resistance", "to Fire Resistance", "to Fire and Lightning Resistances", "to Fire and Cold Resistances", "to Fire and Chaos Resistances", "to all Elemental Resistances")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/GlobalCritChanceFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/GlobalCritChanceFilter.cs
@@ -8,7 +8,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
     public class GlobalCritChanceFilter : ExplicitModBase
     {
         public GlobalCritChanceFilter()
-            : base("increased Global Critical Strike Chance")
+            : base("Global Critical Strike Chance")
         { }
 
         public override bool CanFormCategory
@@ -18,7 +18,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public override string Keyword
         {
-            get { return "Global Crit Chance"; }
+            get { return "Global Critical Strike Chance"; }
         }
 
         public override string Help

--- a/Procurement/ViewModel/Filters/ForumExport/IncreasedDamageFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/IncreasedDamageFilter.cs
@@ -12,24 +12,31 @@
         }
     }
 
+    internal class IncreasedDamageFilterChaos : IncreasedDamageFilter
+    {
+        public IncreasedDamageFilterChaos()
+            : base("Increased Chaos Damage", "Increased Chaos Damage", "increased Chaos Damage")
+        { }
+    }
+
     internal class IncreasedDamageFilterCold : IncreasedDamageFilter
     {
         public IncreasedDamageFilterCold()
-            : base("Increased Cold Damage", "Increased Cold Damage", "Increased Cold Damage")
+            : base("Increased Cold Damage", "Increased Cold Damage", "increased Cold Damage")
         { }
     }
 
     internal class IncreasedDamageFilterFire : IncreasedDamageFilter
     {
         public IncreasedDamageFilterFire()
-            : base("Increased Fire Damage", "Increased Fire Damage", "Increased Fire Damage")
+            : base("Increased Fire Damage", "Increased Fire Damage", "increased Fire Damage")
         { }
     }
 
     internal class IncreasedDamageFilterLightning : IncreasedDamageFilter
     {
         public IncreasedDamageFilterLightning()
-            : base("Increased Lightning Damage", "Increased Lightning Damage", "Increased Lightning Damage")
+            : base("Increased Lightning Damage", "Increased Lightning Damage", "increased Lightning Damage")
         { }
     }
 

--- a/Procurement/ViewModel/Filters/ForumExport/ItemQuantityFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ItemQuantityFilter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Procurement.ViewModel.Filters
 {
-    public class ItemQuantityFilter : StatFilter
+    public class ItemQuantityFilter : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -13,7 +13,7 @@ namespace Procurement.ViewModel.Filters
         }
 
         public ItemQuantityFilter()
-            : base("Item Quantity", "Item with the Item Quantity stat", "INCREASED QUANTITY")
+            : base("Item Quantity", "Items with the Item Quantity stat", "increased Quantity", "increased Item Quantity")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/ItemRarityFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/ItemRarityFilter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Procurement.ViewModel.Filters
 {
-    internal class ItemRarityFilter : StatFilter
+    internal class ItemRarityFilter : OrStatFilter
     {
         public override FilterGroup Group
         {
@@ -8,7 +8,7 @@
         }
 
         public ItemRarityFilter()
-            : base("Item Rarity", "Item with the Item Rarity stat", "INCREASED RARITY")
+            : base("Item Rarity", "Items with the Item Rarity stat", "increased Rarity", "increased Item Rarity")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/LightningResistance.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/LightningResistance.cs
@@ -8,7 +8,7 @@
         }
 
         public LightningResistance()
-            : base("Lightning Resistance", "Lightning Resistance", "to Lightning Resistance", "to Cold and Lightning Resistances", "to Fire and Lightning Resistances")
+            : base("Lightning Resistance", "Lightning Resistance", "to Lightning Resistance", "to Cold and Lightning Resistances", "to Fire and Lightning Resistances", "to Lightning and Chaos Resistances", "to all Elemental Resistances")
         { }
     }
 }

--- a/Procurement/ViewModel/Filters/ForumExport/OrStatFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/OrStatFilter.cs
@@ -28,6 +28,15 @@ namespace Procurement.ViewModel.Filters
             if (gear.Explicitmods != null)
                 all.AddRange(gear.Explicitmods.Select(s => s));
 
+            if (gear.Craftedmods != null)
+                all.AddRange(gear.Craftedmods.Select(s => s));
+
+            if (gear.Fracturedmods != null)
+                all.AddRange(gear.Fracturedmods.Select(s => s));
+
+            if (gear.Enchantmods != null)
+                all.AddRange(gear.Enchantmods.Select(s => s));
+
             foreach (string stat in all)
             {
                 Regex result = pool.Find(s => s.IsMatch(stat));

--- a/Procurement/ViewModel/Filters/ForumExport/StatFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/StatFilter.cs
@@ -28,6 +28,15 @@ namespace Procurement.ViewModel.Filters
             if (gear.Explicitmods != null)
                 all.AddRange(gear.Explicitmods.Select(s => s));
 
+            if (gear.Craftedmods != null)
+                all.AddRange(gear.Craftedmods.Select(s => s));
+
+            if (gear.Fracturedmods != null)
+                all.AddRange(gear.Fracturedmods.Select(s => s));
+
+            if (gear.Enchantmods != null)
+                all.AddRange(gear.Enchantmods.Select(s => s));
+
             foreach (string stat in all)
             {
                 Regex result = pool.Find(s => s.IsMatch(stat));

--- a/Procurement/ViewModel/ForumExportVisitors/ExplicitModVisitor.cs
+++ b/Procurement/ViewModel/ForumExportVisitors/ExplicitModVisitor.cs
@@ -18,6 +18,7 @@ namespace Procurement.ViewModel.ForumExportVisitors
             tokens.Add("{Life}", new LifeFilter());
             tokens.Add("{LifeRegen}", new LifeRegenFilter());
             tokens.Add("{CritChance}", new CritChanceFilter());
+            tokens.Add("{CritMultiplier}", new CritMultiplierFilter());
             tokens.Add("{GlobalCritChance}", new GlobalCritChanceFilter());
             tokens.Add("{GlobalCritMultiplier}", new GlobalCritMultiplierFilter());
             tokens.Add("{SpellDamage}", new SpellDamageFilter());


### PR DESCRIPTION
Filters now also support fractured, crafted and enchanted mods. Added new strings and some new filters.

I didn't add the following strings to IncreasedPhysicalDamageFilter and ManaRegenFilter since I don't know the difference between ExplicitModBase and (Or)StatFilter. Can I just convert them to OrStatFilter?

"increased Global Physical Damage"

"Mana Regenerated per second"
"as extra Mana Regeneration"