### PR TITLE
Improve searching & item hover

### DIFF
--- a/POEApi.Infrastructure/Extensions.cs
+++ b/POEApi.Infrastructure/Extensions.cs
@@ -15,7 +15,7 @@ namespace POEApi.Infrastructure
             StringBuilder sb = new StringBuilder();
 
             foreach (var item in MD5.Create().ComputeHash(Encoding.ASCII.GetBytes(input)))
-                sb.Append(item.ToString("x2").ToLower());
+                sb.Append(item.ToString("x2").ToLowerInvariant());
 
             return sb.ToString();
         }

--- a/POEApi.Model/Gear.cs
+++ b/POEApi.Model/Gear.cs
@@ -10,7 +10,6 @@ namespace POEApi.Model
     {
         public List<Socket> Sockets { get; set; }
         public List<SocketableItem> SocketedItems { get; set; }
-        public List<Requirement> Requirements { get; set; }
         public GearType GearType { get; set; }
         public string BaseType { get; set; }
 
@@ -22,7 +21,6 @@ namespace POEApi.Model
             Explicitmods = item.ExplicitMods;
             SocketedItems = GetSocketedItems(item);
             Implicitmods = item.ImplicitMods;
-            Requirements = ProxyMapper.GetRequirements(item.Requirements);
             ItemType = Model.ItemType.Gear;
             GearType = GearTypeFactory.GetType(this);
             BaseType = GearTypeFactory.GetBaseType(this);

--- a/POEApi.Model/Gear.cs
+++ b/POEApi.Model/Gear.cs
@@ -10,7 +10,6 @@ namespace POEApi.Model
     {
         public List<Socket> Sockets { get; set; }
         public List<SocketableItem> SocketedItems { get; set; }
-        public List<string> Implicitmods { get; set; }
         public List<Requirement> Requirements { get; set; }
         public GearType GearType { get; set; }
         public string BaseType { get; set; }

--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -59,6 +59,7 @@ namespace POEApi.Model
         public List<string> CraftedMods { get; set; }
         public List<string> VeiledMods { get; set; }
         public List<string> FracturedMods { get; set; }
+        public List<string> UtilityMods { get; set; }
 
         public IncubatedDetails IncubatedDetails { get; set; }
 
@@ -105,6 +106,7 @@ namespace POEApi.Model
             VeiledMods = item.VeiledMods ?? new List<string>();
             EnchantMods = item.EnchantMods ?? new List<string>();
             FracturedMods = item.FracturedMods ?? new List<string>();
+            UtilityMods = item.UtilityMods ?? new List<string>();
             FlavourText = item.FlavourText;
             ItemLevel = item.Ilvl;
             Shaper = item.Shaper;

--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -44,6 +44,7 @@ namespace POEApi.Model
         public string InventoryId { get; set; }
         public string SecDescrText { get; private set; }
         public List<string> Explicitmods { get; set; }
+        public List<string> Implicitmods { get; set; }
         public ItemType ItemType { get; set; }
         public List<Property> Properties { get; set; }
         public bool IsQuality { get; private set; }
@@ -52,6 +53,7 @@ namespace POEApi.Model
         public List<string> Microtransactions { get; set; }
         public List<String> EnchantMods { get; set; }
         public List<string> FlavourText { get; set; }
+        public string ProphecyText { get; set; }
 
         public List<string> CraftedMods { get; set; }
         public List<string> VeiledMods { get; set; }
@@ -96,6 +98,7 @@ namespace POEApi.Model
             InventoryId = item.InventoryId;
             SecDescrText = item.SecDescrText;
             Explicitmods = item.ExplicitMods;
+            Implicitmods = item.ImplicitMods;
             ItemType = Model.ItemType.UnSet;
             CraftedMods = item.CraftedMods ?? new List<string>();
             VeiledMods = item.VeiledMods ?? new List<string>();

--- a/POEApi.Model/Item.cs
+++ b/POEApi.Model/Item.cs
@@ -47,6 +47,7 @@ namespace POEApi.Model
         public List<string> Implicitmods { get; set; }
         public ItemType ItemType { get; set; }
         public List<Property> Properties { get; set; }
+        public List<Requirement> Requirements { get; set; }
         public bool IsQuality { get; private set; }
         public int Quality { get; private set; }
         public bool Corrupted { get; private set; }
@@ -113,6 +114,9 @@ namespace POEApi.Model
             StackSize = item.StackSize;
             MaxStackSize = item.MaxStackSize;
             IncubatedDetails = item.IncubatedItem;
+            
+            if (item.Requirements != null)
+                Requirements = ProxyMapper.GetRequirements(item.Requirements);
 
             if (item.Properties != null)
             {

--- a/POEApi.Model/ItemFactory.cs
+++ b/POEApi.Model/ItemFactory.cs
@@ -22,7 +22,7 @@ namespace POEApi.Model
                 if (item.FrameType == 4)
                     return new Gem(item);
 
-                if (item.DescrText != null && item.DescrText.ToLower() == "right click this item then left click a location on the ground to create the object.")
+                if (item.DescrText != null && item.DescrText.ToLowerInvariant() == "right click this item then left click a location on the ground to create the object.")
                     return new Decoration(item);
 
                 if (item.DescrText != null && string.Equals(item.DescrText,
@@ -86,7 +86,7 @@ namespace POEApi.Model
 
         private static Item GetCurrency(JSONProxy.Item item)
         {
-            var typeline = item.TypeLine.ToLower();
+            var typeline = item.TypeLine.ToLowerInvariant();
 
             if (typeline.Contains("essence") || typeline.Contains("remnant of"))
                 return new Essence(item);

--- a/POEApi.Model/JSONProxy/Stash.cs
+++ b/POEApi.Model/JSONProxy/Stash.cs
@@ -78,6 +78,7 @@ namespace POEApi.Model.JSONProxy
         public List<string> EnchantMods { get; set; }
         public List<string> VeiledMods { get; set; }
         public List<string> FracturedMods { get; set; }
+        public List<string> UtilityMods { get; set; }
         public int Ilvl { get; set; }
         public string ProphecyText { get; set; }
         public string ProphecyDiffText { get; set; }

--- a/POEApi.Model/Prophecy.cs
+++ b/POEApi.Model/Prophecy.cs
@@ -4,7 +4,6 @@ namespace POEApi.Model
 {
     public class Prophecy : Item
     {
-        public string ProphecyText { get; set; }
         public string ProphecyDifficultyText { get; set; }
 
         internal Prophecy(JSONProxy.Item item) : base(item)

--- a/POEApi.Model/SocketableItem.cs
+++ b/POEApi.Model/SocketableItem.cs
@@ -4,7 +4,6 @@ namespace POEApi.Model
 {
     public abstract class SocketableItem : Item
     {
-        public List<Requirement> Requirements { get; set; }
 
         public int Socket { get; set; }
         public string Color { get; set; }
@@ -13,7 +12,6 @@ namespace POEApi.Model
         {
             Socket = item.Socket;
             Color = item.Colour;
-            Requirements = ProxyMapper.GetRequirements(item.Requirements);
         }
     }
 }

--- a/POEApi.Transport/HttpTransport.cs
+++ b/POEApi.Transport/HttpTransport.cs
@@ -323,7 +323,7 @@ namespace POEApi.Transport
 
             var title = Regex.Match(html, TitleRegex).Groups["Title"].Value;
 
-            if (!title.ToLower().Contains(threadTitle.ToLower()))
+            if (!title.ToLowerInvariant().Contains(threadTitle.ToLowerInvariant()))
                 throw new ForumThreadException();
 
             return Regex.Match(html, hashRegex).Groups["hash"].Value;

--- a/Procurement/Controls/Inventory.xaml.cs
+++ b/Procurement/Controls/Inventory.xaml.cs
@@ -149,7 +149,7 @@ namespace Procurement.Controls
             if (string.IsNullOrEmpty(Filter))
                 return false;
 
-            return item.TypeLine.ToLower().Contains(Filter.ToLower()) || item.Name.ToLower().Contains(Filter.ToLower());
+            return item.TypeLine.ToLowerInvariant().Contains(Filter.ToLowerInvariant()) || item.Name.ToLowerInvariant().Contains(Filter.ToLowerInvariant());
         }
     }
 }

--- a/Procurement/Controls/ItemDisplay.xaml
+++ b/Procurement/Controls/ItemDisplay.xaml
@@ -27,6 +27,17 @@
                    Visibility="{Binding IsStackSizeVisible,
                                Converter={StaticResource bc},
                                ConverterParameter=CollapseWhenFalse}" />
+
+        <TextBlock HorizontalAlignment="Left"
+                   FontFamily="../Resources/#Fontin SmallCaps"
+                   FontWeight="Medium"
+                   Foreground="#00BAFE"
+                   Text="{Binding StackSize}"
+                   TextAlignment="Center"
+                   TextWrapping="Wrap"
+                   Visibility="{Binding IsFullSetOfCards,
+                               Converter={StaticResource bc},
+                               ConverterParameter=CollapseWhenFalse}" />
     </Grid>
     
     

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -413,9 +413,14 @@
                                                            Mode=OneWay}"
                         Document="{Binding Converter={StaticResource dc}}"
                         Padding="10 0 10 5"
+                        RenderTransformOrigin="0.5,0.5"
                         Visibility="{Binding IsDivinationCard,
                                                                 Converter={StaticResource bc},
-                                                                ConverterParameter=CollapseWhenFalse}" />
+                                                                ConverterParameter=CollapseWhenFalse}">
+                        <v:BindableRichTextBox.RenderTransform>
+                            <ScaleTransform ScaleX="1.1" ScaleY="1.1" />
+                        </v:BindableRichTextBox.RenderTransform>
+                    </v:BindableRichTextBox>
 
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -18,19 +18,7 @@
         <v:DivinationCardToFormattedRunConverter x:Key="dc" />
         <v:ItemFlavourTextToFormattedRunConverter x:Key="fc" />
         <v:VisibilityConverter x:Key="bc" />
-
-        <LinearGradientBrush x:Key="SeperatorBrush" StartPoint="0,0" EndPoint="1,0">
-            <GradientStop Offset="0.25" Color="#00808080" />
-            <GradientStop Offset="0.50" Color="#FF808080" />
-            <GradientStop Offset="0.75" Color="#00808080" />
-        </LinearGradientBrush>
-
-        <LinearGradientBrush x:Key="ProphecySeperatorBrush" StartPoint="0,0" EndPoint="1,0">
-            <GradientStop Offset="0.25" Color="#00808080" />
-            <GradientStop Offset="0.50" Color="#881672" />
-            <GradientStop Offset="0.75" Color="#00808080" />
-        </LinearGradientBrush>
-
+        <v:ItemToSeparatorBrushConverter x:Key="sc" />
 
         <Style TargetType="{x:Type Paragraph}">
             <Setter Property="Margin" Value="0" />
@@ -81,9 +69,6 @@
 
                     <!--
                       KNOWN ISSUES:
-                        - Different dividers between different parts of text are not styled differently.  Instead, the
-                          type of item determines what color the dividers will be.  Examples include: gems,
-                          prophecies, and normal/magic/rare/unique items.
                         - Some sections, under some conditions, have extra space before or between lines.
                     -->
 
@@ -102,9 +87,8 @@
                                ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding ItemLevel,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -156,9 +140,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateProperties,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -173,7 +156,7 @@
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
                             Visibility="{Binding SeparateRequirements,
                                                  Converter={StaticResource VisibilityConverter},
@@ -194,9 +177,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SecondaryDescriptionText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -225,9 +207,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateEnchantMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -255,9 +236,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateImplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -401,9 +381,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -423,9 +402,8 @@
                     </v:BindableRichTextBox>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding IsDivinationCard,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -454,9 +432,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateMicrotransactions,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -471,7 +448,7 @@
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
                             Visibility="{Binding SeparateFlavourText,
                                                  Converter={StaticResource VisibilityConverter},
@@ -492,9 +469,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding ProphecyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -514,9 +490,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding ProphecyDifficultyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -537,7 +512,7 @@
                         </DockPanel>
 
                         <Border Margin="0 0 0 5"
-                                BorderBrush="{StaticResource SeperatorBrush}"
+                                BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                                 BorderThickness="1" />
                     </StackPanel>
 

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -36,6 +36,13 @@
             <Setter Property="FontFamily" Value="../Resources/#Fontin SmallCaps" />
         </Style>
 
+        <Style x:Key="Separator" TargetType="Border">
+            <Setter Property="Margin" Value="0 0 0 5" />
+            <Setter Property="BorderBrush" Value="{Binding Item, Converter={StaticResource sc}}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Width" Value="150" />
+        </Style>
+
         <Style x:Key="ExperienceBarStyle" TargetType="ProgressBar">
             <Setter Property="Minimum" Value="0" />
             <Setter Property="Maximum" Value="1" />
@@ -125,9 +132,7 @@
                                Converter={StaticResource bc},
                                ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding ItemLevel,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -178,9 +183,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateProperties,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -194,9 +197,7 @@
                                                                 Converter={StaticResource bc},
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateRequirements,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -215,9 +216,7 @@
                                                     Converter={StaticResource VisibilityConverter},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SecondaryDescriptionText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -245,9 +244,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateEnchantMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -274,9 +271,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateImplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -419,9 +414,7 @@
                                                     Converter={StaticResource bc},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -435,9 +428,7 @@
                                                                 Converter={StaticResource bc},
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding IsDivinationCard,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -465,9 +456,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateMicrotransactions,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -481,9 +470,7 @@
                                                                 Converter={StaticResource bc},
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateFlavourText,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -502,9 +489,7 @@
                                                     Converter={StaticResource bc},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding ProphecyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -523,9 +508,7 @@
                                                     Converter={StaticResource bc},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding ProphecyDifficultyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -540,9 +523,7 @@
                                Content="{Binding ExperienceNumbers}" Foreground="White" />
                     </StackPanel>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding IsGemProgressVisible,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -107,7 +107,11 @@
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
-                    <ItemsControl ItemsSource="{Binding Properties}" Padding="0 5 0 5">
+                    <ItemsControl ItemsSource="{Binding Properties}"
+                                  Padding="0 5 0 5"
+                                  Visibility="{Binding Properties,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">		    
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <StackPanel Orientation="Vertical" />

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -15,6 +15,8 @@
         <v:ItemPropertyToFormattedRunConverter x:Key="pc" />
         <v:ItemRequirementToFormattedRunConverter x:Key="rc" />
         <v:ItemExplicitModsToFormattedRunConverter x:Key="ec" />
+        <v:DivinationCardToFormattedRunConverter x:Key="dc" />
+        <v:ItemFlavourTextToFormattedRunConverter x:Key="fc" />
         <v:VisibilityConverter x:Key="bc" />
 
         <LinearGradientBrush x:Key="SeperatorBrush" StartPoint="0,0" EndPoint="1,0">
@@ -383,6 +385,23 @@
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
+                    <v:BindableRichTextBox Width="{Binding Path=ActualWidth,
+                                                           ElementName=ItemHeader,
+                                                           Mode=OneWay}"
+                        Document="{Binding Converter={StaticResource dc}}"
+                        Padding="10 0 10 5"
+                        Visibility="{Binding IsDivinationCard,
+                                                                Converter={StaticResource bc},
+                                                                ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding IsDivinationCard,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
                     <ItemsControl ItemsSource="{Binding Microtransactions}"
                                   Padding="10 0 10 5"
                                   Visibility="{Binding HasMicrotransactions,
@@ -414,20 +433,14 @@
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
-                    <TextBlock Width="{Binding Path=ActualWidth,
-                                               ElementName=ItemHeader,
-                                               Mode=OneWay}"
-                        HorizontalAlignment="Center"
-                        FontFamily="../Resources/#Fontin SmallCaps"
-                        FontStyle="Italic"
-                        Foreground="#AF6025"
+                    <v:BindableRichTextBox Width="{Binding Path=ActualWidth,
+                                                           ElementName=ItemHeader,
+                                                           Mode=OneWay}"
+                        Document="{Binding Converter={StaticResource fc}}"
                         Padding="10 0 10 5"
-                        Text="{Binding FlavourText}"
-                        TextAlignment="Center"
-                        TextWrapping="Wrap"
                         Visibility="{Binding FlavourText,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />
+                                                                Converter={StaticResource bc},
+                                                                ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -81,11 +81,7 @@
                       KNOWN ISSUES:
                         - Different dividers between different parts of text are not styled differently.  Instead, the
                           type of item determines what color the dividers will be.  Examples include: gems,
-                          phrophecies, and normal/magic/rare/unique items.
-                        - Items without DescriptionText will have an extra divider at the bottom of the ItemHover
-                          window.  I'm not sure of a good way to exclude it without complicated converters and/or lots
-                          of cascading if/else blocks.  But it looks like dividers are placed correctly between
-                          sections in all cases and all sections are being displayed.
+                          prophecies, and normal/magic/rare/unique items.
                         - Some sections, under some conditions, have extra space before or between lines.
                     -->
 
@@ -134,7 +130,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding Properties,
+                            Visibility="{Binding SeparateProperties,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -150,7 +146,7 @@
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
-                            Visibility="{Binding HasRequirements,
+                            Visibility="{Binding SeparateRequirements,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -203,7 +199,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasEnchantMods,
+                            Visibility="{Binding SeparateEnchantMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -233,7 +229,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasImplicitMods,
+                            Visibility="{Binding SeparateImplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -347,11 +343,39 @@
                                                     Converter={StaticResource VisibilityConverter},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="#D20000"
+                        Padding="10 0 10 5"
+                        Text="Unidentified"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding IsUnidentified,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="#D20000"
+                        Padding="10 0 10 5"
+                        Text="Corrupted"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding IsCorrupted,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasExplicitMods,
+                            Visibility="{Binding SeparateMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -392,7 +416,7 @@
                         HorizontalAlignment="Center"
                         FontFamily="../Resources/#Fontin SmallCaps"
                         FontStyle="Italic"
-                        Foreground="#9E6025"
+                        Foreground="#AF6025"
                         Padding="10 0 10 5"
                         Text="{Binding FlavourText}"
                         TextAlignment="Center"
@@ -404,7 +428,7 @@
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
-                            Visibility="{Binding FlavourText,
+                            Visibility="{Binding SeparateFlavourText,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -452,27 +476,6 @@
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
-                    <TextBlock Width="{Binding Path=ActualWidth,
-                                               ElementName=ItemHeader,
-                                               Mode=OneWay}"
-                        HorizontalAlignment="Center"
-                        FontFamily="../Resources/#Fontin SmallCaps"
-                        Foreground="#960003"
-                        Padding="10 0 10 5"
-                        Text="Corrupted"
-                        TextAlignment="Center"
-                        TextWrapping="Wrap"
-                        Visibility="{Binding IsCorrupted,
-                                                    Converter={StaticResource bc},
-                                                    ConverterParameter=CollapseWhenFalse}" />
-
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
-                            BorderThickness="1"
-                            Visibility="{Binding IsCorrupted,
-                                                 Converter={StaticResource VisibilityConverter},
-                                                 ConverterParameter=CollapseWhenFalse}" />
-
                     <StackPanel Orientation="Vertical"
                                 Visibility="{Binding IsGemProgressVisible,
                                                  Converter={StaticResource VisibilityConverter},
@@ -515,10 +518,6 @@
                                    Content="{Binding IncubationLevel}" Foreground="Gray" />
                             
                         </DockPanel>
-
-                        <Border Margin="0 0 0 5"
-                                BorderBrush="{StaticResource SeperatorBrush}"
-                                BorderThickness="1" />
                     </StackPanel>
 
                     <TextBlock Width="{Binding Path=ActualWidth,

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -132,6 +132,29 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
+                    <ItemsControl ItemsSource="{Binding UtilityMods}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding UtilityMods,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="#FF8888FF"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -111,7 +111,7 @@
                                   Padding="0 5 0 5"
                                   Visibility="{Binding Properties,
                                                        Converter={StaticResource bc},
-                                                       ConverterParameter=CollapseWhenFalse}">		    
+                                                       ConverterParameter=CollapseWhenFalse}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <StackPanel Orientation="Vertical" />
@@ -410,7 +410,7 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasMicrotransactions,
+                            Visibility="{Binding SeparateMicrotransactions,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 

--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -39,10 +39,49 @@
         <Style x:Key="ExperienceBarStyle" TargetType="ProgressBar">
             <Setter Property="Minimum" Value="0" />
             <Setter Property="Maximum" Value="1" />
-            <Setter Property="Margin" Value="2" />
-            <Setter Property="BorderBrush" Value="LightGray" />
-            <Setter Property="Foreground" Value="DarkGoldenrod" />
-            <Setter Property="Height" Value="6" />
+            <Setter Property="Height" Value="10" />
+            <Setter Property="Width" Value="212" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ProgressBar">
+                        <Border BorderBrush="#262A32" BorderThickness="1" CornerRadius="2">
+                            <Border.Background>
+                                <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                                    <GradientStop Color="#FF333B4A" Offset="0.0" />
+                                    <GradientStop Color="#FF11161E" Offset="1.0" />
+                                </LinearGradientBrush>
+                            </Border.Background>
+                            <Grid x:Name="PART_Track">
+                                <Rectangle x:Name="PART_Indicator" HorizontalAlignment="Left">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                                          <GradientStop Color="#FF4B260D" Offset="0.00" />
+                                          <GradientStop Color="#FF4B260D" Offset="0.14" />
+                                          <GradientStop Color="#FFF6BB5C" Offset="0.36" />
+                                          <GradientStop Color="#FFEAE7A9" Offset="0.36" />
+                                          <GradientStop Color="#FFEAE7A9" Offset="0.50" />
+                                          <GradientStop Color="#FFC9A153" Offset="0.50" />
+                                          <GradientStop Color="#FF270904" Offset="0.86" />
+                                          <GradientStop Color="#FF270904" Offset="1.00" />
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </Grid>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="IncubatorSmall" TargetType="Label">
+            <Setter Property="FontFamily" Value="../Resources/#Fontin SmallCaps" />
+            <Setter Property="FontStyle" Value="Italic" />
+            <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
+            <Setter Property="RenderTransform">
+                <Setter.Value>
+                    <ScaleTransform ScaleX="0.9" ScaleY="0.9" />
+                </Setter.Value>
+            </Setter>
         </Style>
 
     </UserControl.Resources>
@@ -392,14 +431,9 @@
                                                            Mode=OneWay}"
                         Document="{Binding Converter={StaticResource dc}}"
                         Padding="10 0 10 5"
-                        RenderTransformOrigin="0.5,0.5"
                         Visibility="{Binding IsDivinationCard,
                                                                 Converter={StaticResource bc},
-                                                                ConverterParameter=CollapseWhenFalse}">
-                        <v:BindableRichTextBox.RenderTransform>
-                            <ScaleTransform ScaleX="1.1" ScaleY="1.1" />
-                        </v:BindableRichTextBox.RenderTransform>
-                    </v:BindableRichTextBox>
+                                                                ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
                             BorderBrush="{Binding Item, Converter={StaticResource sc}}"
@@ -496,25 +530,22 @@
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
-                    <StackPanel Orientation="Vertical"
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 0 0 5"
                                 Visibility="{Binding IsGemProgressVisible,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}">
-                        <DockPanel Margin="10 0 10 5">
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding ExperienceDenominator, FallbackValue=2}" Foreground="White" />
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps" Content="/"
-                                   Foreground="White" />
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding ExperienceNumerator, FallbackValue=1}" Foreground="White" />
-                            <ProgressBar Style="{StaticResource ExperienceBarStyle}"
-                                         Value="{Binding LevelExperienceProgress, FallbackValue=0.5}"  />
-                        </DockPanel>
-
-                        <Border Margin="0 0 0 5"
-                                BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                                BorderThickness="1" />
+                        <ProgressBar Style="{StaticResource ExperienceBarStyle}"
+                                     Value="{Binding LevelExperienceProgress, FallbackValue=0.5, Mode=OneTime}"  />
+                        <Label FontFamily="../Resources/#Fontin SmallCaps"
+                               Content="{Binding ExperienceNumbers}" Foreground="White" />
                     </StackPanel>
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
+                            BorderThickness="1"
+                            Visibility="{Binding IsGemProgressVisible,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Center"
                                 Visibility="{Binding IsIncubatorProgressVisible,
@@ -522,22 +553,14 @@
                                                  ConverterParameter=CollapseWhenFalse}">
                         <Label HorizontalAlignment="Center" FontFamily="../Resources/#Fontin SmallCaps" Content="{Binding Incubating, StringFormat=Incubating {}, FallbackValue='Incubating Some Item'}"
                                Foreground="{StaticResource CraftedModBrush}" />
-
-                        <ProgressBar Style="{StaticResource ExperienceBarStyle}" Margin="10,0"
+                        <ProgressBar Style="{StaticResource ExperienceBarStyle}"
                                      Value="{Binding IncubatorProgress, FallbackValue=0.5, Mode=OneTime}"  />
-                        <DockPanel Margin="10 0 10 5" LastChildFill="True">
-
-                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding IncubatorNumerator, FallbackValue=1}" Foreground="White" />
-                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps" Content="/"
-                                   Foreground="White" />
-                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding IncubatorDenominator, FallbackValue=2}" Foreground="White" />
-                            
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps" FontSize="9" HorizontalAlignment="Center" VerticalAlignment="Center"
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Label Style="{StaticResource IncubatorSmall}" 
+                                   Content="{Binding IncubationNumbers}" Foreground="White" />
+                            <Label Style="{StaticResource IncubatorSmall}"
                                    Content="{Binding IncubationLevel}" Foreground="Gray" />
-                            
-                        </DockPanel>
+                        </StackPanel>
                     </StackPanel>
 
                     <TextBlock Width="{Binding Path=ActualWidth,

--- a/Procurement/Controls/ItemHoverImage.xaml
+++ b/Procurement/Controls/ItemHoverImage.xaml
@@ -36,6 +36,13 @@
             <Setter Property="FontFamily" Value="../Resources/#Fontin SmallCaps" />
         </Style>
 
+        <Style x:Key="Separator" TargetType="Border">
+            <Setter Property="Margin" Value="0 0 0 5" />
+            <Setter Property="BorderBrush" Value="{Binding Item, Converter={StaticResource sc}}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Width" Value="150" />
+        </Style>
+
         <Style x:Key="ExperienceBarStyle" TargetType="ProgressBar">
             <Setter Property="Minimum" Value="0" />
             <Setter Property="Maximum" Value="1" />
@@ -125,9 +132,7 @@
                                Converter={StaticResource bc},
                                ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding ItemLevel,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -178,9 +183,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateProperties,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -194,9 +197,7 @@
                                                                 Converter={StaticResource bc},
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateRequirements,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -215,9 +216,7 @@
                                                     Converter={StaticResource VisibilityConverter},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SecondaryDescriptionText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -245,9 +244,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateEnchantMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -274,9 +271,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateImplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -419,9 +414,7 @@
                                                     Converter={StaticResource bc},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -435,9 +428,7 @@
                                                                 Converter={StaticResource bc},
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding IsDivinationCard,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -465,9 +456,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateMicrotransactions,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -481,9 +470,7 @@
                                                                 Converter={StaticResource bc},
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding SeparateFlavourText,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -502,9 +489,7 @@
                                                     Converter={StaticResource bc},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding ProphecyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -523,9 +508,7 @@
                                                     Converter={StaticResource bc},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding ProphecyDifficultyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -540,9 +523,7 @@
                                Content="{Binding ExperienceNumbers}" Foreground="White" />
                     </StackPanel>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1"
+                    <Border Style="{StaticResource Separator}"
                             Visibility="{Binding IsGemProgressVisible,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -577,9 +558,7 @@
                                                     Converter={StaticResource VisibilityConverter},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                            BorderThickness="1" />
+                    <Border Style="{StaticResource Separator}" />
 
                     <TextBlock Width="{Binding Path=ActualWidth,
                                                ElementName=ItemHeader,

--- a/Procurement/Controls/ItemHoverImage.xaml
+++ b/Procurement/Controls/ItemHoverImage.xaml
@@ -5,13 +5,18 @@
              xmlns:local="clr-namespace:Procurement.Controls"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:v="clr-namespace:Procurement.View"
+             xmlns:vm="clr-namespace:Procurement.ViewModel"
              mc:Ignorable="d">
 
     <UserControl.Resources>
+        <SolidColorBrush x:Key="CraftedModBrush">#B4B4FF</SolidColorBrush>
+
         <v:VisibilityConverter x:Key="VisibilityConverter" />
         <v:ItemPropertyToFormattedRunConverter x:Key="pc" />
         <v:ItemRequirementToFormattedRunConverter x:Key="rc" />
         <v:ItemExplicitModsToFormattedRunConverter x:Key="ec" />
+        <v:DivinationCardToFormattedRunConverter x:Key="dc" />
+        <v:ItemFlavourTextToFormattedRunConverter x:Key="fc" />
         <v:VisibilityConverter x:Key="bc" />
 
         <LinearGradientBrush x:Key="SeperatorBrush" StartPoint="0,0" EndPoint="1,0">
@@ -19,6 +24,13 @@
             <GradientStop Offset="0.50" Color="#FF808080" />
             <GradientStop Offset="0.75" Color="#00808080" />
         </LinearGradientBrush>
+
+        <LinearGradientBrush x:Key="ProphecySeperatorBrush" StartPoint="0,0" EndPoint="1,0">
+            <GradientStop Offset="0.25" Color="#00808080" />
+            <GradientStop Offset="0.50" Color="#881672" />
+            <GradientStop Offset="0.75" Color="#00808080" />
+        </LinearGradientBrush>
+
 
         <Style TargetType="{x:Type Paragraph}">
             <Setter Property="Margin" Value="0" />
@@ -34,6 +46,15 @@
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="FontFamily" Value="../Resources/#Fontin SmallCaps" />
+        </Style>
+
+        <Style x:Key="ExperienceBarStyle" TargetType="ProgressBar">
+            <Setter Property="Minimum" Value="0" />
+            <Setter Property="Maximum" Value="1" />
+            <Setter Property="Margin" Value="2" />
+            <Setter Property="BorderBrush" Value="LightGray" />
+            <Setter Property="Foreground" Value="DarkGoldenrod" />
+            <Setter Property="Height" Value="6" />
         </Style>
 
     </UserControl.Resources>
@@ -58,7 +79,41 @@
                 </Border.Background>
                 <StackPanel>
 
-                    <ItemsControl ItemsSource="{Binding Properties}" Padding="0 5 0 5">
+                    <!--
+                      KNOWN ISSUES:
+                        - Different dividers between different parts of text are not styled differently.  Instead, the
+                          type of item determines what color the dividers will be.  Examples include: gems,
+                          prophecies, and normal/magic/rare/unique items.
+                        - Some sections, under some conditions, have extra space before or between lines.
+                    -->
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="White"
+                        Padding="10 0 10 5"
+                        Text="{Binding ItemLevel}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding ItemLevel,
+                               Converter={StaticResource bc},
+                               ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding ItemLevel,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <ItemsControl ItemsSource="{Binding Properties}"
+                                  Padding="0 5 0 5"
+                                  Visibility="{Binding Properties,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <StackPanel Orientation="Vertical" />
@@ -67,7 +122,11 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel>
-                                    <v:BindableRichTextBox Width="{Binding Path=ActualWidth, ElementName=ItemHeader, Mode=OneWay}" Document="{Binding Converter={StaticResource pc}}" />
+                                    <v:BindableRichTextBox
+                                        Width="{Binding Path=ActualWidth,
+                                                ElementName=ItemHeader,
+                                                Mode=OneWay}"
+                                        Document="{Binding Converter={StaticResource pc}}" />
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -77,37 +136,37 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasRequirements,
+                            Visibility="{Binding SeparateProperties,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
                     <v:BindableRichTextBox Width="{Binding Path=ActualWidth,
                                                            ElementName=ItemHeader,
                                                            Mode=OneWay}"
-                                           Document="{Binding Converter={StaticResource rc}}"
-                                           Padding="10 0 10 5"
-                                           Visibility="{Binding HasRequirements,
+                        Document="{Binding Converter={StaticResource rc}}"
+                        Padding="10 0 10 5"
+                        Visibility="{Binding HasRequirements,
                                                                 Converter={StaticResource bc},
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
-                            Visibility="{Binding SecondaryDescriptionText,
+                            Visibility="{Binding SeparateRequirements,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
                     <TextBlock Width="{Binding Path=ActualWidth,
                                                ElementName=ItemHeader,
                                                Mode=OneWay}"
-                               HorizontalAlignment="Center"
-                               FontFamily="../Resources/#Fontin SmallCaps"
-                               Foreground="Turquoise"
-                               Padding="10 0 10 5"
-                               Text="{Binding SecondaryDescriptionText}"
-                               TextAlignment="Center"
-                               TextWrapping="Wrap"
-                               Visibility="{Binding SecondaryDescriptionText,
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="Turquoise"
+                        Padding="10 0 10 5"
+                        Text="{Binding SecondaryDescriptionText}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding SecondaryDescriptionText,
                                                     Converter={StaticResource VisibilityConverter},
                                                     ConverterParameter=CollapseWhenFalse}" />
 
@@ -115,7 +174,38 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasImplicitMods,
+                            Visibility="{Binding SecondaryDescriptionText,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <ItemsControl ItemsSource="{Binding EnchantMods}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding HasEnchantMods,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="{StaticResource CraftedModBrush}"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding SeparateEnchantMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
@@ -145,9 +235,32 @@
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasExplicitMods,
+                            Visibility="{Binding SeparateImplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
+
+                    <ItemsControl ItemsSource="{Binding FracturedMods}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding HasFracturedMods,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="#a29162"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
 
                     <ItemsControl ItemsSource="{Binding ExplicitMods}"
                                   Padding="10 0 10 5"
@@ -172,27 +285,6 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
-                            BorderThickness="1"
-                            Visibility="{Binding DescriptionText,
-                                                 Converter={StaticResource VisibilityConverter},
-                                                 ConverterParameter=CollapseWhenFalse}" />
-
-                    <TextBlock Width="{Binding Path=ActualWidth,
-                                               ElementName=ItemHeader,
-                                               Mode=OneWay}"
-                               HorizontalAlignment="Center"
-                               FontFamily="../Resources/#Fontin SmallCaps"
-                               Foreground="Gray"
-                               Padding="10 0 10 5"
-                               Text="{Binding DescriptionText}"
-                               TextAlignment="Center"
-                               TextWrapping="Wrap"
-                               Visibility="{Binding DescriptionText,
-                                                    Converter={StaticResource VisibilityConverter},
-                                                    ConverterParameter=CollapseWhenFalse}" />
-
                     <ItemsControl ItemsSource="{Binding CraftedMods}"
                                   Padding="10 0 10 5"
                                   Visibility="{Binding HasCraftedMods,
@@ -207,37 +299,263 @@
                             <DataTemplate>
                                 <StackPanel>
                                     <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
-                                               Foreground="#b4b4ff"
+                                               Foreground="{StaticResource CraftedModBrush}"
                                                Text="{Binding}"
                                                TextAlignment="Center"
                                                TextWrapping="Wrap" />
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
-                    </ItemsControl>                    
-                    
+                    </ItemsControl>
+
+                    <ItemsControl ItemsSource="{Binding VeiledMods}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding HasVeiledMods,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="{StaticResource CraftedModBrush}"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- The pseudo-explicit property "Mirrored" should appear after any real explicit mods and any
+                         crafted mods.  It is mutually exclusive with being corrupted. -->
+                    <!-- TODO: Padding bug: there is extra padding between explicit mods, crafted mods, and the
+                               mirrored property is any two exist, due to the extra 5 padding below each. -->
                     <TextBlock Width="{Binding Path=ActualWidth,
                                                ElementName=ItemHeader,
                                                Mode=OneWay}"
-                               HorizontalAlignment="Center"
-                               FontFamily="../Resources/#Fontin SmallCaps"
-                               Foreground="#960003"
-                               Padding="10 0 10 5"
-                               Text="Corrupted"
-                               TextAlignment="Center"
-                               TextWrapping="Wrap"
-                               Visibility="{Binding IsCorrupted,
-                               Converter={StaticResource bc},
-                               ConverterParameter=CollapseWhenFalse}" />
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="#FF8888FF"
+                        Padding="10 0 10 5"
+                        Text="Mirrored"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding IsMirrored,
+                                                    Converter={StaticResource VisibilityConverter},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="#D20000"
+                        Padding="10 0 10 5"
+                        Text="Unidentified"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding IsUnidentified,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="#D20000"
+                        Padding="10 0 10 5"
+                        Text="Corrupted"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding IsCorrupted,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
                             Opacity="0.7"
-                            Visibility="{Binding HasExplicitMods,
+                            Visibility="{Binding SeparateMods,
                                                  Converter={StaticResource bc},
-                                                 ConverterParameter=CollapseWhenFalse}" />                    
-                    
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <v:BindableRichTextBox Width="{Binding Path=ActualWidth,
+                                                           ElementName=ItemHeader,
+                                                           Mode=OneWay}"
+                        Document="{Binding Converter={StaticResource dc}}"
+                        Padding="10 0 10 5"
+                        Visibility="{Binding IsDivinationCard,
+                                                                Converter={StaticResource bc},
+                                                                ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding IsDivinationCard,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <ItemsControl ItemsSource="{Binding Microtransactions}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding HasMicrotransactions,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="#FFAA9E82"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding SeparateMicrotransactions,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <v:BindableRichTextBox Width="{Binding Path=ActualWidth,
+                                                           ElementName=ItemHeader,
+                                                           Mode=OneWay}"
+                        Document="{Binding Converter={StaticResource fc}}"
+                        Padding="10 0 10 5"
+                        Visibility="{Binding FlavourText,
+                                                                Converter={StaticResource bc},
+                                                                ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding SeparateFlavourText,
+                                                 Converter={StaticResource VisibilityConverter},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="White"
+                        Padding="10 0 10 5"
+                        Text="{Binding ProphecyText}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding ProphecyText,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding ProphecyText,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="#FF808080"
+                        Padding="10 0 10 5"
+                        Text="{Binding ProphecyDifficultyText}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding ProphecyDifficultyText,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7"
+                            Visibility="{Binding ProphecyDifficultyText,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
+
+                    <StackPanel Orientation="Vertical"
+                                Visibility="{Binding IsGemProgressVisible,
+                                                 Converter={StaticResource VisibilityConverter},
+                                                 ConverterParameter=CollapseWhenFalse}">
+                        <DockPanel Margin="10 0 10 5">
+                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps"
+                                   Content="{Binding ExperienceDenominator, FallbackValue=2}" Foreground="White" />
+                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps" Content="/"
+                                   Foreground="White" />
+                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps"
+                                   Content="{Binding ExperienceNumerator, FallbackValue=1}" Foreground="White" />
+                            <ProgressBar Style="{StaticResource ExperienceBarStyle}"
+                                         Value="{Binding LevelExperienceProgress, FallbackValue=0.5}"  />
+                        </DockPanel>
+
+                        <Border Margin="0 0 0 5"
+                                BorderBrush="{StaticResource SeperatorBrush}"
+                                BorderThickness="1" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Center"
+                                Visibility="{Binding IsIncubatorProgressVisible,
+                                                 Converter={StaticResource VisibilityConverter},
+                                                 ConverterParameter=CollapseWhenFalse}">
+                        <Label HorizontalAlignment="Center" FontFamily="../Resources/#Fontin SmallCaps" Content="{Binding Incubating, StringFormat=Incubating {}, FallbackValue='Incubating Some Item'}"
+                               Foreground="{StaticResource CraftedModBrush}" />
+
+                        <ProgressBar Style="{StaticResource ExperienceBarStyle}" Margin="10,0"
+                                     Value="{Binding IncubatorProgress, FallbackValue=0.5, Mode=OneTime}"  />
+                        <DockPanel Margin="10 0 10 5" LastChildFill="True">
+
+                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps"
+                                   Content="{Binding IncubatorNumerator, FallbackValue=1}" Foreground="White" />
+                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps" Content="/"
+                                   Foreground="White" />
+                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps"
+                                   Content="{Binding IncubatorDenominator, FallbackValue=2}" Foreground="White" />
+                            
+                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps" FontSize="9" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                   Content="{Binding IncubationLevel}" Foreground="Gray" />
+                            
+                        </DockPanel>
+                    </StackPanel>
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="Gray"
+                        Padding="10 0 10 5"
+                        Text="{Binding DescriptionText}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding DescriptionText,
+                                                    Converter={StaticResource VisibilityConverter},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderThickness="1"
+                            Opacity="0.7" />
+
                     <TextBlock Width="{Binding Path=ActualWidth,
                                                ElementName=ItemHeader,
                                                Mode=OneWay}"
@@ -249,7 +567,6 @@
                                TextAlignment="Center"
                                TextWrapping="Wrap"
                                Visibility="Visible" />
-
                 </StackPanel>
             </Border>
         </DockPanel>

--- a/Procurement/Controls/ItemHoverImage.xaml
+++ b/Procurement/Controls/ItemHoverImage.xaml
@@ -132,6 +132,29 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
+                    <ItemsControl ItemsSource="{Binding UtilityMods}"
+                                  Padding="10 0 10 5"
+                                  Visibility="{Binding UtilityMods,
+                                                       Converter={StaticResource bc},
+                                                       ConverterParameter=CollapseWhenFalse}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock FontFamily="../Resources/#Fontin SmallCaps"
+                                               Foreground="#FF8888FF"
+                                               Text="{Binding}"
+                                               TextAlignment="Center"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"

--- a/Procurement/Controls/ItemHoverImage.xaml
+++ b/Procurement/Controls/ItemHoverImage.xaml
@@ -39,10 +39,49 @@
         <Style x:Key="ExperienceBarStyle" TargetType="ProgressBar">
             <Setter Property="Minimum" Value="0" />
             <Setter Property="Maximum" Value="1" />
-            <Setter Property="Margin" Value="2" />
-            <Setter Property="BorderBrush" Value="LightGray" />
-            <Setter Property="Foreground" Value="DarkGoldenrod" />
-            <Setter Property="Height" Value="6" />
+            <Setter Property="Height" Value="10" />
+            <Setter Property="Width" Value="212" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ProgressBar">
+                        <Border BorderBrush="#262A32" BorderThickness="1" CornerRadius="2">
+                            <Border.Background>
+                                <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                                    <GradientStop Color="#FF333B4A" Offset="0.0" />
+                                    <GradientStop Color="#FF11161E" Offset="1.0" />
+                                </LinearGradientBrush>
+                            </Border.Background>
+                            <Grid x:Name="PART_Track">
+                                <Rectangle x:Name="PART_Indicator" HorizontalAlignment="Left">
+                                    <Rectangle.Fill>
+                                        <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                                          <GradientStop Color="#FF4B260D" Offset="0.00" />
+                                          <GradientStop Color="#FF4B260D" Offset="0.14" />
+                                          <GradientStop Color="#FFF6BB5C" Offset="0.36" />
+                                          <GradientStop Color="#FFEAE7A9" Offset="0.36" />
+                                          <GradientStop Color="#FFEAE7A9" Offset="0.50" />
+                                          <GradientStop Color="#FFC9A153" Offset="0.50" />
+                                          <GradientStop Color="#FF270904" Offset="0.86" />
+                                          <GradientStop Color="#FF270904" Offset="1.00" />
+                                        </LinearGradientBrush>
+                                    </Rectangle.Fill>
+                                </Rectangle>
+                            </Grid>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="IncubatorSmall" TargetType="Label">
+            <Setter Property="FontFamily" Value="../Resources/#Fontin SmallCaps" />
+            <Setter Property="FontStyle" Value="Italic" />
+            <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
+            <Setter Property="RenderTransform">
+                <Setter.Value>
+                    <ScaleTransform ScaleX="0.9" ScaleY="0.9" />
+                </Setter.Value>
+            </Setter>
         </Style>
 
     </UserControl.Resources>
@@ -491,25 +530,22 @@
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
 
-                    <StackPanel Orientation="Vertical"
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 0 0 5"
                                 Visibility="{Binding IsGemProgressVisible,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}">
-                        <DockPanel Margin="10 0 10 5">
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding ExperienceDenominator, FallbackValue=2}" Foreground="White" />
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps" Content="/"
-                                   Foreground="White" />
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding ExperienceNumerator, FallbackValue=1}" Foreground="White" />
-                            <ProgressBar Style="{StaticResource ExperienceBarStyle}"
-                                         Value="{Binding LevelExperienceProgress, FallbackValue=0.5}"  />
-                        </DockPanel>
-
-                        <Border Margin="0 0 0 5"
-                                BorderBrush="{Binding Item, Converter={StaticResource sc}}"
-                                BorderThickness="1" />
+                        <ProgressBar Style="{StaticResource ExperienceBarStyle}"
+                                     Value="{Binding LevelExperienceProgress, FallbackValue=0.5, Mode=OneTime}"  />
+                        <Label FontFamily="../Resources/#Fontin SmallCaps"
+                               Content="{Binding ExperienceNumbers}" Foreground="White" />
                     </StackPanel>
+
+                    <Border Margin="0 0 0 5"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
+                            BorderThickness="1"
+                            Visibility="{Binding IsGemProgressVisible,
+                                                 Converter={StaticResource bc},
+                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <StackPanel Orientation="Vertical" HorizontalAlignment="Center"
                                 Visibility="{Binding IsIncubatorProgressVisible,
@@ -517,22 +553,14 @@
                                                  ConverterParameter=CollapseWhenFalse}">
                         <Label HorizontalAlignment="Center" FontFamily="../Resources/#Fontin SmallCaps" Content="{Binding Incubating, StringFormat=Incubating {}, FallbackValue='Incubating Some Item'}"
                                Foreground="{StaticResource CraftedModBrush}" />
-
-                        <ProgressBar Style="{StaticResource ExperienceBarStyle}" Margin="10,0"
+                        <ProgressBar Style="{StaticResource ExperienceBarStyle}"
                                      Value="{Binding IncubatorProgress, FallbackValue=0.5, Mode=OneTime}"  />
-                        <DockPanel Margin="10 0 10 5" LastChildFill="True">
-
-                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding IncubatorNumerator, FallbackValue=1}" Foreground="White" />
-                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps" Content="/"
-                                   Foreground="White" />
-                            <Label DockPanel.Dock="Left" FontFamily="../Resources/#Fontin SmallCaps"
-                                   Content="{Binding IncubatorDenominator, FallbackValue=2}" Foreground="White" />
-                            
-                            <Label DockPanel.Dock="Right" FontFamily="../Resources/#Fontin SmallCaps" FontSize="9" HorizontalAlignment="Center" VerticalAlignment="Center"
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Label Style="{StaticResource IncubatorSmall}" 
+                                   Content="{Binding IncubationNumbers}" Foreground="White" />
+                            <Label Style="{StaticResource IncubatorSmall}"
                                    Content="{Binding IncubationLevel}" Foreground="Gray" />
-                            
-                        </DockPanel>
+                        </StackPanel>
                     </StackPanel>
 
                     <TextBlock Width="{Binding Path=ActualWidth,

--- a/Procurement/Controls/ItemHoverImage.xaml
+++ b/Procurement/Controls/ItemHoverImage.xaml
@@ -18,19 +18,7 @@
         <v:DivinationCardToFormattedRunConverter x:Key="dc" />
         <v:ItemFlavourTextToFormattedRunConverter x:Key="fc" />
         <v:VisibilityConverter x:Key="bc" />
-
-        <LinearGradientBrush x:Key="SeperatorBrush" StartPoint="0,0" EndPoint="1,0">
-            <GradientStop Offset="0.25" Color="#00808080" />
-            <GradientStop Offset="0.50" Color="#FF808080" />
-            <GradientStop Offset="0.75" Color="#00808080" />
-        </LinearGradientBrush>
-
-        <LinearGradientBrush x:Key="ProphecySeperatorBrush" StartPoint="0,0" EndPoint="1,0">
-            <GradientStop Offset="0.25" Color="#00808080" />
-            <GradientStop Offset="0.50" Color="#881672" />
-            <GradientStop Offset="0.75" Color="#00808080" />
-        </LinearGradientBrush>
-
+        <v:ItemToSeparatorBrushConverter x:Key="sc" />
 
         <Style TargetType="{x:Type Paragraph}">
             <Setter Property="Margin" Value="0" />
@@ -81,9 +69,6 @@
 
                     <!--
                       KNOWN ISSUES:
-                        - Different dividers between different parts of text are not styled differently.  Instead, the
-                          type of item determines what color the dividers will be.  Examples include: gems,
-                          prophecies, and normal/magic/rare/unique items.
                         - Some sections, under some conditions, have extra space before or between lines.
                     -->
 
@@ -102,9 +87,8 @@
                                ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding ItemLevel,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -156,9 +140,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateProperties,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -173,7 +156,7 @@
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
                             Visibility="{Binding SeparateRequirements,
                                                  Converter={StaticResource VisibilityConverter},
@@ -194,9 +177,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SecondaryDescriptionText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -225,9 +207,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateEnchantMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -255,9 +236,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateImplicitMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -401,9 +381,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateMods,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -418,9 +397,8 @@
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding IsDivinationCard,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -449,9 +427,8 @@
                     </ItemsControl>
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding SeparateMicrotransactions,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -466,7 +443,7 @@
                                                                 ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
                             Visibility="{Binding SeparateFlavourText,
                                                  Converter={StaticResource VisibilityConverter},
@@ -487,9 +464,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding ProphecyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -509,9 +485,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource ProphecySeperatorBrush}"
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                             BorderThickness="1"
-                            Opacity="0.7"
                             Visibility="{Binding ProphecyDifficultyText,
                                                  Converter={StaticResource bc},
                                                  ConverterParameter=CollapseWhenFalse}" />
@@ -532,7 +507,7 @@
                         </DockPanel>
 
                         <Border Margin="0 0 0 5"
-                                BorderBrush="{StaticResource SeperatorBrush}"
+                                BorderBrush="{Binding Item, Converter={StaticResource sc}}"
                                 BorderThickness="1" />
                     </StackPanel>
 
@@ -575,9 +550,8 @@
                                                     ConverterParameter=CollapseWhenFalse}" />
 
                     <Border Margin="0 0 0 5"
-                            BorderBrush="{StaticResource SeperatorBrush}"
-                            BorderThickness="1"
-                            Opacity="0.7" />
+                            BorderBrush="{Binding Item, Converter={StaticResource sc}}"
+                            BorderThickness="1" />
 
                     <TextBlock Width="{Binding Path=ActualWidth,
                                                ElementName=ItemHeader,

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -391,9 +391,11 @@
     <Compile Include="View\Converters\CharacterToImageConverter.cs" />
     <Compile Include="View\Converters\CharacterToLevelConverter.cs" />
     <Compile Include="View\Converters\CurrencyCraftingSlotScalingConverter.cs" />
+    <Compile Include="View\Converters\DivinationCardToFormattedRunConverter.cs" />
     <Compile Include="View\Converters\FilterListToNameConverter.cs" />
     <Compile Include="View\Converters\ItemDisplayConverter.cs" />
     <Compile Include="View\Converters\ItemExplicitModsToFormattedRunConverter.cs" />
+    <Compile Include="View\Converters\ItemFlavourTextToFormattedRunConverter.cs" />
     <Compile Include="View\Converters\ItemPropertyToFormattedRunConverter.cs" />
     <Compile Include="View\Converters\ItemRequirementToFormattedRunConverter.cs" />
     <Compile Include="View\Converters\ItemToColorBrushConverter.cs" />

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -401,6 +401,7 @@
     <Compile Include="View\Converters\ItemToColorBrushConverter.cs" />
     <Compile Include="View\Converters\ItemToItemHoverSymbolPath.cs" />
     <Compile Include="View\Converters\ItemToItemHoverSymbolVisibility.cs" />
+    <Compile Include="View\Converters\ItemToSeparatorBrushConverter.cs" />
     <Compile Include="View\Converters\ObjectInListMultiConverter.cs" />
     <Compile Include="View\Converters\RecipeDescriptionConverter.cs" />
     <Compile Include="View\Converters\ResultMatchConverter.cs" />

--- a/Procurement/Utility/ItemHoverRenderer.cs
+++ b/Procurement/Utility/ItemHoverRenderer.cs
@@ -22,10 +22,17 @@ namespace Procurement.Utility
             {
                 createSaveFolder();
 
+                string name = "";
+
+                if (string.IsNullOrEmpty(item.Name))
+                    name = item.TypeLine;
+                else
+                    name = item.Name + " " + item.TypeLine;
+
                 SaveFileDialog saveDialog = new SaveFileDialog();
 
                 saveDialog.InitialDirectory = string.Format("{0}\\{1}", Environment.CurrentDirectory, SAVE_LOCATION);
-                saveDialog.FileName = string.Format("{0} - {1}.png", item.Name, DateTime.Now.ToString("dd-MM-yyyy-HH-mm-ss"));
+                saveDialog.FileName = string.Format("{0} - {1}.png", name, DateTime.Now.ToString("dd-MM-yyyy-HH-mm-ss"));
                 saveDialog.Filter = "png files (*.png)|*.png|All files (*.*)|*.*";
                 saveDialog.FilterIndex = 2;
                 saveDialog.RestoreDirectory = true;
@@ -55,7 +62,7 @@ namespace Procurement.Utility
                     encoder.Save(fileStream);
                 }
 
-                MessageBox.Show("Image saved", item.Name + " saved", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(name + " saved.", "Image saved", MessageBoxButton.OK, MessageBoxImage.Information);
             }
             catch (Exception ex)
             {

--- a/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
@@ -25,11 +25,12 @@ namespace Procurement.View
 
             var paragraph = new Paragraph();
 
-            Match match = Regex.Match(mods.First(), "<(augmented|corrupted|currencyitem|default|divination|gemitem|magicitem|normal|prophecy|rareitem|uniqueitem|whiteitem)>{(.+?)}(\r\n)?");
+            Match match = Regex.Match(mods.First(), "<([a-z]+)>{(.+?)}( |\r\n)?");
 
             while (match.Success)
             {
                 string colortext = match.Groups[1].Value;
+                string spaceornewline = match.Groups[3].Value;
                 string color = "";
 
                 if (colortext.Equals("augmented"))
@@ -56,11 +57,13 @@ namespace Procurement.View
                     color = "#AF6025";
                 else if (colortext.Equals("whiteitem"))
                     color = "#C8C8C8";
+                else
+                    color = "#7F7F7F";
 
                 paragraph.Inlines.Add(new Run(match.Groups[2].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color)) });
 
-                if (match.Groups[3].Value.Equals("\r\n"))
-                    paragraph.Inlines.Add(new Run("\r\n"));
+                if (!string.IsNullOrEmpty(spaceornewline))
+                    paragraph.Inlines.Add(new Run(spaceornewline));
 
                 match = match.NextMatch();
             }

--- a/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
@@ -18,7 +18,7 @@ namespace Procurement.View
         {
             var viewModel = value as ItemHoverViewModel;
 
-            if (viewModel == null || !viewModel.IsDivinationCard || viewModel.ExplicitMods.Count == 0)
+            if (viewModel == null || !viewModel.IsDivinationCard || viewModel.ExplicitMods == null || viewModel.ExplicitMods.Count == 0)
                 return null;
 
             var paragraph = new Paragraph();

--- a/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Data;
+using POEApi.Model;
+using System.Windows.Documents;
+using Procurement.ViewModel;
+using System.Windows.Media;
+using System.Windows;
+using System.Text.RegularExpressions;
+
+namespace Procurement.View
+{
+    public class DivinationCardToFormattedRunConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var viewModel = value as ItemHoverViewModel;
+
+            if (viewModel == null || !viewModel.IsDivinationCard || viewModel.ExplicitMods.Count == 0)
+                return null;
+
+            var mods = viewModel.ExplicitMods;
+
+            Paragraph paragraph = new Paragraph();
+
+            Match match = Regex.Match(mods.First(), "<(augmented|corrupted|currencyitem|default|divination|gemitem|magicitem|normal|prophecy|rareitem|uniqueitem|whiteitem)>{(.+?)}(\r\n)?");
+
+            while (match.Success)
+            {
+                string colortext = match.Groups[1].Value;
+                string color = "";
+
+                if (colortext.Equals("augmented"))
+                    color = "#8888FF";
+                else if (colortext.Equals("corrupted"))
+                    color = "#D20000";
+                else if (colortext.Equals("currencyitem"))
+                    color = "#AA9E82";
+                else if (colortext.Equals("default"))
+                    color = "#7F7F7F";
+                else if (colortext.Equals("divination"))
+                    color = "#AAE6E6";
+                else if (colortext.Equals("gemitem"))
+                    color = "#1BA29B";
+                else if (colortext.Equals("magicitem"))
+                    color = "#8888FF";
+                else if (colortext.Equals("normal"))
+                    color = "#C8C8C8";
+                else if (colortext.Equals("prophecy"))
+                    color = "#B54BFF";
+                else if (colortext.Equals("rareitem"))
+                    color = "#FFFF77";
+                else if (colortext.Equals("uniqueitem"))
+                    color = "#AF6025";
+                else if (colortext.Equals("whiteitem"))
+                    color = "#C8C8C8";
+
+                paragraph.Inlines.Add(new Run(match.Groups[2].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color)), BaselineAlignment = BaselineAlignment.Center });
+
+                if (match.Groups[3].Value.Equals("\r\n"))
+                    paragraph.Inlines.Add(new Run("\r\n"));
+
+                match = match.NextMatch();
+            }
+
+            return new FlowDocument(paragraph);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
@@ -21,11 +21,9 @@ namespace Procurement.View
             if (viewModel == null || !viewModel.IsDivinationCard || viewModel.ExplicitMods.Count == 0)
                 return null;
 
-            var mods = viewModel.ExplicitMods;
-
             var paragraph = new Paragraph();
 
-            Match match = Regex.Match(mods.First(), "<([a-z]+)>{(.+?)}( |\r\n)?");
+            Match match = Regex.Match(viewModel.ExplicitMods.First(), "<([a-z]+)>{(.+?)}( |\r\n)?");
 
             while (match.Success)
             {

--- a/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/DivinationCardToFormattedRunConverter.cs
@@ -23,7 +23,7 @@ namespace Procurement.View
 
             var mods = viewModel.ExplicitMods;
 
-            Paragraph paragraph = new Paragraph();
+            var paragraph = new Paragraph();
 
             Match match = Regex.Match(mods.First(), "<(augmented|corrupted|currencyitem|default|divination|gemitem|magicitem|normal|prophecy|rareitem|uniqueitem|whiteitem)>{(.+?)}(\r\n)?");
 
@@ -57,7 +57,7 @@ namespace Procurement.View
                 else if (colortext.Equals("whiteitem"))
                     color = "#C8C8C8";
 
-                paragraph.Inlines.Add(new Run(match.Groups[2].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color)), BaselineAlignment = BaselineAlignment.Center });
+                paragraph.Inlines.Add(new Run(match.Groups[2].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color)) });
 
                 if (match.Groups[3].Value.Equals("\r\n"))
                     paragraph.Inlines.Add(new Run("\r\n"));

--- a/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
@@ -22,26 +22,29 @@ namespace Procurement.View
                 return null;
 
             string flavourtext = viewModel.FlavourText;
-            Paragraph paragraph = new Paragraph();
 
             if (viewModel.IsDivinationCard && (flavourtext.StartsWith("<size:") || flavourtext.StartsWith("<smaller>{")))
                 flavourtext = flavourtext.TrimEnd('}').Substring(10);
 
             if (flavourtext.Contains("<d"))
             {
-                Match match = Regex.Match(flavourtext, "(.*?)<default>{(.+?)}(.*?)");
+                Match match = Regex.Match(flavourtext, "(.*?)<default>{(.+?)}(.*)");
 
                 if (match.Success)
                 {
-                    paragraph.Inlines.Add(new Run(match.Groups[1].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic });
-                    paragraph.Inlines.Add(new Run(match.Groups[2].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#7F7F7F")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic });
-                    paragraph.Inlines.Add(new Run(match.Groups[3].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic });
+                    var paragraph = new Paragraph();
+
+                    paragraph.Inlines.Add(new Run(match.Groups[1].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), FontStyle = FontStyles.Italic });
+                    paragraph.Inlines.Add(new Run(match.Groups[2].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#7F7F7F")), FontStyle = FontStyles.Italic });
+
+                    if (!string.IsNullOrEmpty(match.Groups[3].Value))
+                        paragraph.Inlines.Add(new Run(match.Groups[3].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), FontStyle = FontStyles.Italic });
 
                     return new FlowDocument(paragraph);
                 }
             }
 
-            return new FlowDocument(new Paragraph(new Run(flavourtext) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic }));
+            return new FlowDocument(new Paragraph(new Run(flavourtext) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), FontStyle = FontStyles.Italic }));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Data;
+using POEApi.Model;
+using System.Windows.Documents;
+using Procurement.ViewModel;
+using System.Windows.Media;
+using System.Windows;
+using System.Text.RegularExpressions;
+
+namespace Procurement.View
+{
+    public class ItemFlavourTextToFormattedRunConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var viewModel = value as ItemHoverViewModel;
+
+            if (viewModel == null || string.IsNullOrEmpty(viewModel.FlavourText))
+                return null;
+
+            string flavourtext = viewModel.FlavourText;
+            Paragraph paragraph = new Paragraph();
+
+            if (flavourtext.StartsWith("<size:"))
+                flavourtext = flavourtext.TrimEnd('}').Substring(10);
+
+            if (flavourtext.Contains("<d"))
+            {
+                Match match = Regex.Match(flavourtext, "(.*?)<default>{(.+?)}(.*?)");
+
+                if (match.Success)
+                {
+                    paragraph.Inlines.Add(new Run(match.Groups[1].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic });
+                    paragraph.Inlines.Add(new Run(match.Groups[2].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#7F7F7F")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic });
+                    paragraph.Inlines.Add(new Run(match.Groups[3].Value) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic });
+
+                    return new FlowDocument(paragraph);
+                }
+            }
+
+            return new FlowDocument(new Paragraph(new Run(flavourtext) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AF6025")), BaselineAlignment = BaselineAlignment.Center, FontStyle = FontStyles.Italic }));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
@@ -26,7 +26,7 @@ namespace Procurement.View
             if (viewModel.IsDivinationCard && (flavourtext.StartsWith("<size:") || flavourtext.StartsWith("<smaller>{")))
                 flavourtext = flavourtext.TrimEnd('}').Substring(10);
 
-            if (flavourtext.Contains("<d"))
+            if (viewModel.Item.Rarity == Rarity.Unique && flavourtext.Contains("<d"))
             {
                 Match match = Regex.Match(flavourtext, "(.*?)<default>{(.+?)}(.*)");
 

--- a/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
@@ -24,7 +24,7 @@ namespace Procurement.View
             string flavourtext = viewModel.FlavourText;
             Paragraph paragraph = new Paragraph();
 
-            if (flavourtext.StartsWith("<size:") || flavourtext.StartsWith("<smaller>{"))
+            if (viewModel.IsDivinationCard && (flavourtext.StartsWith("<size:") || flavourtext.StartsWith("<smaller>{")))
                 flavourtext = flavourtext.TrimEnd('}').Substring(10);
 
             if (flavourtext.Contains("<d"))

--- a/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
+++ b/Procurement/View/Converters/ItemFlavourTextToFormattedRunConverter.cs
@@ -24,7 +24,7 @@ namespace Procurement.View
             string flavourtext = viewModel.FlavourText;
             Paragraph paragraph = new Paragraph();
 
-            if (flavourtext.StartsWith("<size:"))
+            if (flavourtext.StartsWith("<size:") || flavourtext.StartsWith("<smaller>{"))
                 flavourtext = flavourtext.TrimEnd('}').Substring(10);
 
             if (flavourtext.Contains("<d"))

--- a/Procurement/View/Converters/ItemToSeparatorBrushConverter.cs
+++ b/Procurement/View/Converters/ItemToSeparatorBrushConverter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows;
+
+using POEApi.Model;
+
+namespace Procurement.View
+{
+    public class ItemToSeparatorBrushConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var item = value as Item;
+            string color;
+
+            if (item is Gem)
+                color = "305C56";
+            else if (item is Prophecy)
+                color = "822B76";
+            else if (item is QuestItem)
+                color = "34532B";
+            else if (item is Currency || item is Sextant || item is Essence || item is Fossil || item is Resonator || item is BreachSplinter || item is LegionSplinter)
+                color = "5F573F";
+            else if (item.Rarity == Rarity.Unique)
+                color = "85442B";
+            else if (item.Rarity == Rarity.Rare)
+                color = "85622B";
+            else if (item.Rarity == Rarity.Magic)
+                color = "443470";
+            else
+                color = "52463A";
+
+            return new LinearGradientBrush()
+            {
+                StartPoint = new Point(0, 0),
+                EndPoint = new Point(1, 0),
+                GradientStops = new GradientStopCollection()
+                {
+                    new GradientStop((Color)ColorConverter.ConvertFromString("#00" + color), 0.25),
+                    new GradientStop((Color)ColorConverter.ConvertFromString("#FF" + color), 0.50),
+                    new GradientStop((Color)ColorConverter.ConvertFromString("#00" + color), 0.75)
+                }
+            };
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Procurement/View/Converters/ItemToSeparatorBrushConverter.cs
+++ b/Procurement/View/Converters/ItemToSeparatorBrushConverter.cs
@@ -13,6 +13,25 @@ namespace Procurement.View
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var item = value as Item;
+
+            if (item.Rarity == Rarity.Relic)
+            {
+                return new LinearGradientBrush()
+                {
+                    StartPoint = new Point(0, 0),
+                    EndPoint = new Point(1, 0),
+                    GradientStops = new GradientStopCollection()
+                    {
+                        new GradientStop((Color)ColorConverter.ConvertFromString("#004F3D07"), 0.00),
+                        new GradientStop((Color)ColorConverter.ConvertFromString("#FF4F3D07"), 0.30),
+                        new GradientStop((Color)ColorConverter.ConvertFromString("#FF506B3F"), 0.45),
+                        new GradientStop((Color)ColorConverter.ConvertFromString("#FF506B3F"), 0.55),
+                        new GradientStop((Color)ColorConverter.ConvertFromString("#FF142F51"), 0.70),
+                        new GradientStop((Color)ColorConverter.ConvertFromString("#00142F51"), 1.00)
+                    }
+                };
+            }
+
             string color;
 
             if (item is Gem)
@@ -38,9 +57,10 @@ namespace Procurement.View
                 EndPoint = new Point(1, 0),
                 GradientStops = new GradientStopCollection()
                 {
-                    new GradientStop((Color)ColorConverter.ConvertFromString("#00" + color), 0.25),
-                    new GradientStop((Color)ColorConverter.ConvertFromString("#FF" + color), 0.50),
-                    new GradientStop((Color)ColorConverter.ConvertFromString("#00" + color), 0.75)
+                    new GradientStop((Color)ColorConverter.ConvertFromString("#00" + color), 0.0),
+                    new GradientStop((Color)ColorConverter.ConvertFromString("#FF" + color), 0.4),
+                    new GradientStop((Color)ColorConverter.ConvertFromString("#FF" + color), 0.6),
+                    new GradientStop((Color)ColorConverter.ConvertFromString("#00" + color), 1.0)
                 }
             };
         }

--- a/Procurement/View/StashView.xaml
+++ b/Procurement/View/StashView.xaml
@@ -192,7 +192,7 @@
                                     </TransformGroup>
                                 </Label.RenderTransform>
                             </Label>
-                            <toolkit:AutoCompleteBox x:Name="autoComplete" MinimumPopulateDelay="100" MinimumPrefixLength="2" FilterMode="ContainsOrdinal" Background="Black" Text="{Binding Filter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" BorderBrush="{StaticResource BorderBrush}" Foreground="{StaticResource TextForecolour}" ItemsSource="{Binding AvailableItems}" Margin="0,4,-1,2" RenderTransformOrigin="0.498,0.438" Grid.Column="1" />
+                            <toolkit:AutoCompleteBox x:Name="autoComplete" MinimumPopulateDelay="100" MinimumPrefixLength="2" FilterMode="ContainsOrdinal" Background="Black" Text="{Binding Filter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Delay=250}" BorderBrush="{StaticResource BorderBrush}" Foreground="{StaticResource TextForecolour}" ItemsSource="{Binding AvailableItems}" Margin="0,4,-1,2" RenderTransformOrigin="0.498,0.438" Grid.Column="1" />
                         </Grid>
                     </Grid>
                 </Border>

--- a/Procurement/View/StashView.xaml
+++ b/Procurement/View/StashView.xaml
@@ -192,7 +192,7 @@
                                     </TransformGroup>
                                 </Label.RenderTransform>
                             </Label>
-                            <toolkit:AutoCompleteBox x:Name="autoComplete" MinimumPopulateDelay="100" MinimumPrefixLength="2" FilterMode="Contains" Background="Black" Text="{Binding Filter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" BorderBrush="{StaticResource BorderBrush}" Foreground="{StaticResource TextForecolour}" ItemsSource="{Binding AvailableItems}" Margin="0,4,-1,2" RenderTransformOrigin="0.498,0.438" Grid.Column="1" />
+                            <toolkit:AutoCompleteBox x:Name="autoComplete" MinimumPopulateDelay="100" MinimumPrefixLength="2" FilterMode="ContainsOrdinal" Background="Black" Text="{Binding Filter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" BorderBrush="{StaticResource BorderBrush}" Foreground="{StaticResource TextForecolour}" ItemsSource="{Binding AvailableItems}" Margin="0,4,-1,2" RenderTransformOrigin="0.498,0.438" Grid.Column="1" />
                         </Grid>
                     </Grid>
                 </Border>

--- a/Procurement/View/StashView.xaml.cs
+++ b/Procurement/View/StashView.xaml.cs
@@ -47,7 +47,7 @@ namespace Procurement.View
 
             foreach (AdvancedSearchCategory category in AdvancedSearchItemControl.ItemsSource)
             {
-                if (category.Key.ToLower().Contains(cb.Text.ToLower()))
+                if (category.Key.ToLowerInvariant().Contains(cb.Text.ToLowerInvariant()))
                 {
                     category.IsVisible = true;
                 }

--- a/Procurement/View/StashView.xaml.cs
+++ b/Procurement/View/StashView.xaml.cs
@@ -47,7 +47,7 @@ namespace Procurement.View
 
             foreach (AdvancedSearchCategory category in AdvancedSearchItemControl.ItemsSource)
             {
-                if (category.Key.ToLowerInvariant().Contains(cb.Text.ToLowerInvariant()))
+                if (category.Key.ToLowerInvariant().Contains(cb.Text.ToLowerInvariant()) || category.Value.ToLowerInvariant().Contains(cb.Text.ToLowerInvariant()))
                 {
                     category.IsVisible = true;
                 }

--- a/Procurement/ViewModel/DisplayModeStrategy/NamePlusValueStrategy.cs
+++ b/Procurement/ViewModel/DisplayModeStrategy/NamePlusValueStrategy.cs
@@ -13,12 +13,23 @@ namespace Procurement.ViewModel
 
         public override Block Get()
         {
-            Paragraph ret;
+            Paragraph ret = new Paragraph();
             if (property.Values.Count == 0)
-                ret = new Paragraph(new Run(property.Name) { Foreground = Brushes.Gray });
+            {
+                if (property.Name.StartsWith("Requires <unmet>{"))
+                {
+                    ret.Inlines.Add(new Run("Requires ") { Foreground = Brushes.Gray });
+                    ret.Inlines.Add(new Run(property.Name[17].ToString()) { Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#D20000")) });
+                    ret.Inlines.Add(new Run(property.Name.Substring(19)) { Foreground = Brushes.Gray });
+                }
+                else
+                {
+                    ret.Inlines.Add(new Run(property.Name) { Foreground = Brushes.Gray });
+                }
+            }
             else
             {
-                ret = new Paragraph(new Run(property.Name + ":") { Foreground = Brushes.Gray });
+                ret.Inlines.Add(new Run(property.Name + ":") { Foreground = Brushes.Gray });
 
                 for (int i = 0; i < property.Values.Count; i++)
                 {

--- a/Procurement/ViewModel/DisplayModeStrategy/NamePlusValueStrategy.cs
+++ b/Procurement/ViewModel/DisplayModeStrategy/NamePlusValueStrategy.cs
@@ -13,15 +13,20 @@ namespace Procurement.ViewModel
 
         public override Block Get()
         {
-            Paragraph ret = new Paragraph(new Run(property.Name) { Foreground = Brushes.Gray });
-         
-            for (int i = 0; i < property.Values.Count; i++)
+            Paragraph ret;
+            if (property.Values.Count == 0)
+                ret = new Paragraph(new Run(property.Name) { Foreground = Brushes.Gray });
+            else
             {
-                ret.Inlines.Add(new Run(" " + (property.Values[i].Item1)) { Foreground = base.displayColorMappings[property.Values[i].Item2]});
-                if (i != property.Values.Count - 1)
-                    ret.Inlines.Add(new Run(", ") { Foreground = Brushes.Gray });
-            }
+                ret = new Paragraph(new Run(property.Name + ":") { Foreground = Brushes.Gray });
 
+                for (int i = 0; i < property.Values.Count; i++)
+                {
+                    ret.Inlines.Add(new Run(" " + (property.Values[i].Item1)) { Foreground = base.displayColorMappings[property.Values[i].Item2]});
+                    if (i != property.Values.Count - 1)
+                        ret.Inlines.Add(new Run(", ") { Foreground = Brushes.Gray });
+                }
+            }
             return ret;
         }
     }

--- a/Procurement/ViewModel/Filters/ForumExport/BuyoutFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/BuyoutFilter.cs
@@ -43,8 +43,8 @@ namespace Procurement.ViewModel.Filters.ForumExport
             {
                 var itemInfo = Settings.Buyouts[item.Id];
 
-                isItemBuyout = itemInfo.Buyout.ToLower() == buyoutValue.ToLower();
-                isItemPriced = itemInfo.Price.ToLower() == buyoutValue.ToLower();
+                isItemBuyout = itemInfo.Buyout.ToLowerInvariant() == buyoutValue.ToLowerInvariant();
+                isItemPriced = itemInfo.Price.ToLowerInvariant() == buyoutValue.ToLowerInvariant();
             }
 
             isTabBuyout = Settings.TabsBuyouts.ContainsKey(ApplicationState.Stash[ApplicationState.CurrentLeague].GetTabNameByInventoryId(item.InventoryId));

--- a/Procurement/ViewModel/Filters/ForumExport/EssenceFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/EssenceFilter.cs
@@ -38,7 +38,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public bool Applicable(Item item)
         {
-            var loweredTypeLine = item.TypeLine.ToLower();
+            var loweredTypeLine = item.TypeLine.ToLowerInvariant();
             return loweredTypeLine.Contains("essence") || loweredTypeLine.Contains("remnant of");
         }
     }

--- a/Procurement/ViewModel/Filters/ForumExport/GemCategoryFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/GemCategoryFilter.cs
@@ -44,7 +44,7 @@ namespace Procurement.ViewModel.Filters
 
             try
             {
-                return gem.Properties[0].Name.ToLower().Contains(filter.ToLower());
+                return gem.Properties[0].Name.ToLowerInvariant().Contains(filter.ToLowerInvariant());
             }
             catch (Exception)
             {

--- a/Procurement/ViewModel/Filters/ForumExport/LeagestoneFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/LeagestoneFilter.cs
@@ -14,7 +14,7 @@ namespace Procurement.ViewModel.Filters.ForumExport
 
         public bool Applicable(Item item)
         {
-            return item.TypeLine.ToLower().Contains("leaguestone");
+            return item.TypeLine.ToLowerInvariant().Contains("leaguestone");
         }
     }
 }

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -192,61 +192,63 @@ namespace Procurement.ViewModel.Filters
                             goto End;
                 }
 
+                string text = "";
+
                 if (map != null)
-                    if (item.Rarity.ToString().ToLowerInvariant().Contains(word))
+                {
+                    text = "rarity: " + item.Rarity.ToString().ToLowerInvariant();
+                    if (text.Contains(word))
                         goto End;
+                }
 
                 if (gear != null)
-                    if (!gear.GearType.Equals(GearType.Unknown) && !gear.GearType.Equals(GearType.DivinationCard) && !gear.GearType.Equals(GearType.Breachstone))
-                        if (item.Rarity.ToString().ToLowerInvariant().Contains(word))
+                    if (!gear.GearType.Equals(GearType.Unknown)
+                     && !gear.GearType.Equals(GearType.DivinationCard)
+                     && !gear.GearType.Equals(GearType.Breachstone))
+                    {
+                        text = "rarity: " + item.Rarity.ToString().ToLowerInvariant();
+                        if (text.Contains(word))
                             goto End;
+                    }
 
-                string text = "";
+                if (item.ItemLevel > 0)
+                {
+                    text = "item level: " + item.ItemLevel.ToString();
+                    if (text.Contains(word))
+                        goto End;
+                }
+
                 if (item.EnchantMods != null && item.EnchantMods.Count > 0)
                 {
                     text = "enchanted";
                     if (text.Contains(word))
                         goto End;
                 }
+
                 if (item.CraftedMods != null && item.CraftedMods.Count > 0)
                 {
                     text = "crafted";
                     if (text.Contains(word))
                         goto End;
                 }
+
                 if (item.Fractured)
                 {
                     text = "fractured";
                     if (text.Contains(word))
                         goto End;
                 }
+
                 if (item.Corrupted)
                 {
                     text = "corrupted";
                     if (text.Contains(word))
                         goto End;
                 }
+
                 if (!item.Identified)
                 {
                     text = "unidentified";
-                    if (text.Contains(word))
-                        goto End;
-                }
-                if (item.ItemLevel > 0)
-                {
-                    text = item.ItemLevel.ToString();
-                    if (text.Contains(word))
-                        goto End;
-                }
-                if (item.StackSize > 0)
-                {
-                    text = item.StackSize.ToString();
-                    if (text.Contains(word))
-                        goto End;
-                }
-                if (item.MaxStackSize > 0)
-                {
-                    text = item.MaxStackSize.ToString();
                     if (text.Contains(word))
                         goto End;
                 }

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -40,13 +40,12 @@ namespace Procurement.ViewModel.Filters
 
             string[] words = filter.ToLowerInvariant().Split(' ');
 
-            int matchedcount = 0;
+            int count = 0;
 
             foreach (var splitword in words)
             {
                 var word = splitword;
 
-                bool matched = false;
                 bool dontmatch = false;
 
                 if (word.StartsWith("-"))
@@ -56,51 +55,111 @@ namespace Procurement.ViewModel.Filters
                 }
 
                 if (item.TypeLine.ToLowerInvariant().Contains(word) || item.Name.ToLowerInvariant().Contains(word))
-                    matched = true;
+                {
+                    count++;
+                    goto End;
+                }
 
-                if (item.Explicitmods != null && !matched)
+                if (item.Explicitmods != null)
+                {
                     foreach (var mod in item.Explicitmods)
+                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
+                    }
+                }
 
-                if (item.Implicitmods != null && !matched)
+                if (item.Implicitmods != null)
+                {
                     foreach (var mod in item.Implicitmods)
+                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
+                    }
+                }
 
-                if (item.FracturedMods != null && !matched)
+                if (item.FracturedMods != null)
+                {
                     foreach (var mod in item.FracturedMods)
+                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
+                    }
+                }
 
-                if (item.CraftedMods != null && !matched)
+                if (item.CraftedMods != null)
+                {
                     foreach (var mod in item.CraftedMods)
+                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
+                    }
+                }
 
-                if (item.EnchantMods != null && !matched)
+                if (item.EnchantMods != null)
+                {
                     foreach (var mod in item.EnchantMods)
+                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
+                    }
+                }
 
-                if (item.FlavourText != null && !matched)
-                    foreach (var text in item.FlavourText)
-                        if (text.ToLowerInvariant().Contains(word))
-                            matched = true;
+                if (item.FlavourText != null)
+                {
+                    foreach (var flavourtext in item.FlavourText)
+                    {
+                        if (flavourtext.ToLowerInvariant().Contains(word))
+                        {
+                            count++;
+                            goto End;
+                        }
+                    }
+                }
 
-                if (item.DescrText != null && !matched)
+                if (item.DescrText != null)
+                {
                     if (item.DescrText.ToLowerInvariant().Contains(word))
-                        matched = true;
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
 
-                if (item.SecDescrText != null && !matched)
+                if (item.SecDescrText != null)
+                {
                     if (item.SecDescrText.ToLowerInvariant().Contains(word))
-                        matched = true;
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
 
-                if (item.ProphecyText != null && !matched)
+                if (item.ProphecyText != null)
+                {
                     if (item.ProphecyText.ToLowerInvariant().Contains(word))
-                        matched = true;
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
 
-                if ((item is Map || item is Gear) && !matched)
+                if (item is Map || item is Gear)
                 {
                     string rarity = null;
 
@@ -127,64 +186,88 @@ namespace Procurement.ViewModel.Filters
                             rarity = "relic";
 
                         if (rarity.Contains(word))
-                            matched = true;
-                    }
-                }
-                
-                if (!matched)
-                {
-                    string text = null;
-                    if (item.EnchantMods != null && item.EnchantMods.Count() > 0)
-                    {
-                        text = "enchanted";
-                        if (text.Contains(word))
-                            matched = true;
-                    }
-                    if (item.CraftedMods != null && item.CraftedMods.Count() > 0 && !matched)
-                    {
-                        text = "crafted";
-                        if (text.Contains(word))
-                            matched = true;
-                    }
-                    if (item.Fractured && !matched)
-                    {
-                        text = "fractured";
-                        if (text.Contains(word))
-                            matched = true;
-                    }
-                    if (item.Corrupted && !matched)
-                    {
-                        text = "corrupted";
-                        if (text.Contains(word))
-                            matched = true;
-                    }
-                    if (!item.Identified && !matched)
-                    {
-                        text = "unidentified";
-                        if (text.Contains(word))
-                            matched = true;
-                    }
-                    if (item.ItemLevel > 0 && !matched)
-                    {
-                        text = item.ItemLevel.ToString();
-                        if (text.Contains(word))
-                            matched = true;
-                    }
-                    if (item.StackSize > 0 && !matched)
-                    {
-                        text = item.StackSize.ToString();
-                        if (text.Contains(word))
-                            matched = true;
-                    }
-                    if (item.MaxStackSize > 0 && !matched)
-                    {
-                        text = item.MaxStackSize.ToString();
-                        if (text.Contains(word))
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
                     }
                 }
 
-                if (word.StartsWith("tier:") && item is Map &&!matched)
+                string text = null;
+                if (item.EnchantMods != null && item.EnchantMods.Count() > 0)
+                {
+                    text = "enchanted";
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+                if (item.CraftedMods != null && item.CraftedMods.Count() > 0)
+                {
+                    text = "crafted";
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+                if (item.Fractured)
+                {
+                    text = "fractured";
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+                if (item.Corrupted)
+                {
+                    text = "corrupted";
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+                if (!item.Identified)
+                {
+                    text = "unidentified";
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+                if (item.ItemLevel > 0)
+                {
+                    text = item.ItemLevel.ToString();
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+                if (item.StackSize > 0)
+                {
+                    text = item.StackSize.ToString();
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+                if (item.MaxStackSize > 0)
+                {
+                    text = item.MaxStackSize.ToString();
+                    if (text.Contains(word))
+                    {
+                        count++;
+                        goto End;
+                    }
+                }
+
+                if (word.StartsWith("tier:") && item is Map)
                 {
                     int tier;
                     bool greaterthan = false;
@@ -208,16 +291,25 @@ namespace Procurement.ViewModel.Filters
                         if (map != null)
                         {
                             if (greaterthan && tier <= map.MapTier)
-                                matched = true;
+                            {
+                                count++;
+                                goto End;
+                            }
                             else if (lessthan && tier >= map.MapTier)
-                                matched = true;
+                            {
+                                count++;
+                                goto End;
+                            }
                             else if (tier == map.MapTier)
-                                matched = true;
+                            {
+                                count++;
+                                goto End;
+                            }
                         }
                     }
                 }
 
-                if (word.StartsWith("ilvl:") && item.ItemLevel > 0 && !matched)
+                if (word.StartsWith("ilvl:") && item.ItemLevel > 0)
                 {
                     int ilvl;
                     bool greaterthan = false;
@@ -237,19 +329,34 @@ namespace Procurement.ViewModel.Filters
                     if (ilvl >= 1 && ilvl <= 100)
                     {
                         if (greaterthan && ilvl <= item.ItemLevel)
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
                         else if (lessthan && ilvl >= item.ItemLevel)
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
                         else if (ilvl == item.ItemLevel)
-                            matched = true;
+                        {
+                            count++;
+                            goto End;
+                        }
                     }
                 }
+                
+                if (dontmatch)
+                    count++;
 
-                if ((matched && !dontmatch) || (!matched && dontmatch))
-                    matchedcount++;
+                continue;
+
+                End:
+                    if (dontmatch)
+                        count--;
             }
 
-            if (words.Count() == matchedcount)
+            if (words.Count() == count)
                 return true;
 
             var gear = item as Gear;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -196,10 +196,8 @@ namespace Procurement.ViewModel.Filters
             {
                 List<string> inctext = new List<string>();
 
-                inctext.Add($"{item.IncubatedDetails.Progress}");
-                inctext.Add($"{item.IncubatedDetails.Total}");
-                inctext.Add($"{item.IncubatedDetails.Progress:n0}");
-                inctext.Add($"{item.IncubatedDetails.Total:n0}");
+                inctext.Add($"{item.IncubatedDetails.Progress}/{item.IncubatedDetails.Total}");
+                inctext.Add($"{item.IncubatedDetails.Progress:n0}/{item.IncubatedDetails.Total:n0}");
                 inctext.Add($"Incubating {item.IncubatedDetails.Name}");
                 inctext.Add($"Level {item.IncubatedDetails.Level}+ Monster Kills");
 
@@ -339,10 +337,8 @@ namespace Procurement.ViewModel.Filters
                 {
                     List<string> exptext = new List<string>();
 
-                    exptext.Add($"{gem.ExperienceNumerator}");
-                    exptext.Add($"{gem.ExperienceDenominator}");
-                    exptext.Add($"{gem.ExperienceNumerator:n0}");
-                    exptext.Add($"{gem.ExperienceDenominator:n0}");
+                    exptext.Add($"{gem.ExperienceNumerator}/{gem.ExperienceDenominator}");
+                    exptext.Add($"{gem.ExperienceNumerator:n0}/{gem.ExperienceDenominator:n0}");
 
                     if (exptext.Any(x => x.ToLowerInvariant().Contains(word)))
                         goto End;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -332,6 +332,8 @@ namespace Procurement.ViewModel.Filters
                 End:
                     if (!dontmatch)
                         count++;
+                    else
+                        break;
             }
 
             if (words.Count() == count)

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -64,8 +64,12 @@ namespace Procurement.ViewModel.Filters
 
                 if (word.StartsWith("-"))
                 {
-                    dontmatch = true;
                     word = word.Remove(0, 1);
+
+                    if (string.IsNullOrEmpty(word))
+                        goto End;
+
+                    dontmatch = true;
                 }
 
                 if (item.TypeLine.ToLowerInvariant().Contains(word))

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -370,6 +370,33 @@ namespace Procurement.ViewModel.Filters
                     goto End;
             }
 
+            if (!string.IsNullOrEmpty(item.Id) && Settings.Buyouts.ContainsKey(item.Id))
+            {
+                text = "priced";
+                if (text.Contains(word))
+                    goto End;
+
+                string price = Settings.Buyouts[item.Id].Buyout;
+
+                if (string.IsNullOrEmpty(price))
+                    price = Settings.Buyouts[item.Id].Price;
+                else
+                {
+                    text = "buyout";
+                    if (text.Contains(word))
+                    goto End;
+                }
+
+                if (price.Contains(word))
+                    goto End;
+            }
+            else if (!(item is QuestItem) && !(item is Decoration))
+            {
+                text = "unpriced";
+                if (text.StartsWith(word))
+                    goto End;
+            }
+
             if (gear?.Sockets.Count > 0)
             {
                 List<string> sockettext = new List<string>();

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -167,7 +167,7 @@ namespace Procurement.ViewModel.Filters
                     }
                 }
 
-                if ((item is Gem || gear != null) && item.Requirements != null)
+                if ((item is Gem || gear != null || item is AbyssJewel) && item.Requirements != null)
                 {
                     string reqtext = "Requires ";
                     int reqcount = 1;
@@ -228,6 +228,32 @@ namespace Procurement.ViewModel.Filters
                         goto End;
                 }
 
+                if (item.Implicitmods != null)
+                {
+                    if (item.Implicitmods.Count == 1)
+                    {
+                        text = "implicit";
+                        if (text.Contains(word))
+                            goto End;
+                    }
+                    else if (item.Implicitmods.Count == 2)
+                    {
+                        text = "two-implicit";
+                        if (text.Contains(word))
+                            goto End;
+                        text = "double implicit";
+                        if (text.Contains(word))
+                            goto End;
+                    }
+                }
+
+                if (item.IsMirrored)
+                {
+                    text = "mirrored";
+                    if (text.Contains(word))
+                        goto End;
+                }
+
                 if (item.EnchantMods != null && item.EnchantMods.Count > 0)
                 {
                     text = "enchanted";
@@ -262,12 +288,32 @@ namespace Procurement.ViewModel.Filters
                     if (text.Contains(word))
                         goto End;
                 }
+
                 if (item is FullBestiaryOrb)
                 {
                     text = "captured beast";
                     if (text.Contains(word))
                         goto End;
                 }
+
+                if (item is Gem)
+                {
+                    text = "gem";
+                    if (text.Contains(word))
+                        goto End;
+                }
+
+                if (gear != null)
+                    if (gear.GearType.Equals(GearType.Unknown))
+                        if (gear.TypeLine.StartsWith("Sacrifice at ")
+                         || gear.TypeLine.StartsWith("Mortal ")
+                         || gear.TypeLine.StartsWith("Fragment of the ")
+                         || gear.TypeLine.EndsWith(" Key"))
+                        {
+                            text = "map fragment";
+                            if (text.Contains(word))
+                                goto End;
+                        }
 
                 if (word.StartsWith("tier:") && map != null)
                 {

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -372,23 +372,51 @@ namespace Procurement.ViewModel.Filters
 
             if (!string.IsNullOrEmpty(item.Id) && Settings.Buyouts.ContainsKey(item.Id))
             {
-                text = "priced";
-                if (text.Contains(word))
+                var itemInfo = Settings.Buyouts[item.Id];
+
+                List<string> pricetext = new List<string>();
+
+                pricetext.Add(itemInfo.Buyout);
+                pricetext.Add(itemInfo.CurrentOffer);
+                pricetext.Add(itemInfo.Price);
+                pricetext.Add(itemInfo.Notes);
+
+                if (pricetext.Any(x => x.ToLowerInvariant().Contains(word)))
                     goto End;
 
-                string price = Settings.Buyouts[item.Id].Buyout;
-
-                if (string.IsNullOrEmpty(price))
-                    price = Settings.Buyouts[item.Id].Price;
+                if (!string.IsNullOrEmpty(itemInfo.Buyout) || !string.IsNullOrEmpty(itemInfo.Price))
+                {
+                    text = "priced";
+                    if (text.Contains(word))
+                    goto End;
+                }
                 else
+                {
+                    text = "unpriced";
+                    if (text.StartsWith(word))
+                        goto End;
+                }
+
+                if (!string.IsNullOrEmpty(itemInfo.Buyout))
                 {
                     text = "buyout";
                     if (text.Contains(word))
                     goto End;
                 }
 
-                if (price.Contains(word))
+                if (!string.IsNullOrEmpty(itemInfo.CurrentOffer))
+                {
+                    text = "offer";
+                    if (text.Contains(word))
                     goto End;
+                }
+
+                if (!string.IsNullOrEmpty(itemInfo.Notes))
+                {
+                    text = "notes";
+                    if (text.Contains(word))
+                    goto End;
+                }
             }
             else if (!(item is QuestItem) && !(item is Decoration))
             {

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -184,7 +184,7 @@ namespace Procurement.ViewModel.Filters
                     }
                 }
 
-                if (word.StartsWith("tier:") && !matched)
+                if (word.StartsWith("tier:") && item is Map &&!matched)
                 {
                     int tier;
                     bool greaterthan = false;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -54,100 +54,53 @@ namespace Procurement.ViewModel.Filters
                     word = word.Remove(0, 1);
                 }
 
-                if (item.TypeLine.ToLowerInvariant().Contains(word) || item.Name.ToLowerInvariant().Contains(word))
-                {
+                if (item.TypeLine.ToLowerInvariant().Contains(word))
                     goto End;
-                }
+
+                if (item.Name.ToLowerInvariant().Contains(word))
+                    goto End;
 
                 if (item.Explicitmods != null)
-                {
                     foreach (var mod in item.Explicitmods)
-                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                        {
                             goto End;
-                        }
-                    }
-                }
 
                 if (item.Implicitmods != null)
-                {
                     foreach (var mod in item.Implicitmods)
-                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                        {
                             goto End;
-                        }
-                    }
-                }
 
                 if (item.FracturedMods != null)
-                {
                     foreach (var mod in item.FracturedMods)
-                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                        {
                             goto End;
-                        }
-                    }
-                }
 
                 if (item.CraftedMods != null)
-                {
                     foreach (var mod in item.CraftedMods)
-                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                        {
                             goto End;
-                        }
-                    }
-                }
 
                 if (item.EnchantMods != null)
-                {
                     foreach (var mod in item.EnchantMods)
-                    {
                         if (mod.ToLowerInvariant().Contains(word))
-                        {
                             goto End;
-                        }
-                    }
-                }
 
                 if (item.FlavourText != null)
-                {
                     foreach (var flavourtext in item.FlavourText)
-                    {
                         if (flavourtext.ToLowerInvariant().Contains(word))
-                        {
                             goto End;
-                        }
-                    }
-                }
 
                 if (item.DescrText != null)
-                {
                     if (item.DescrText.ToLowerInvariant().Contains(word))
-                    {
                         goto End;
-                    }
-                }
 
                 if (item.SecDescrText != null)
-                {
                     if (item.SecDescrText.ToLowerInvariant().Contains(word))
-                    {
                         goto End;
-                    }
-                }
 
                 if (item.ProphecyText != null)
-                {
                     if (item.ProphecyText.ToLowerInvariant().Contains(word))
-                    {
                         goto End;
-                    }
-                }
 
                 if (item is Map || item is Gear)
                 {
@@ -176,9 +129,7 @@ namespace Procurement.ViewModel.Filters
                             rarity = "relic";
 
                         if (rarity.Contains(word))
-                        {
                             goto End;
-                        }
                     }
                 }
 
@@ -187,65 +138,49 @@ namespace Procurement.ViewModel.Filters
                 {
                     text = "enchanted";
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
                 if (item.CraftedMods != null && item.CraftedMods.Count() > 0)
                 {
                     text = "crafted";
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
                 if (item.Fractured)
                 {
                     text = "fractured";
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
                 if (item.Corrupted)
                 {
                     text = "corrupted";
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
                 if (!item.Identified)
                 {
                     text = "unidentified";
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
                 if (item.ItemLevel > 0)
                 {
                     text = item.ItemLevel.ToString();
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
                 if (item.StackSize > 0)
                 {
                     text = item.StackSize.ToString();
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
                 if (item.MaxStackSize > 0)
                 {
                     text = item.MaxStackSize.ToString();
                     if (text.Contains(word))
-                    {
                         goto End;
-                    }
                 }
 
                 if (word.StartsWith("tier:") && item is Map)
@@ -272,17 +207,11 @@ namespace Procurement.ViewModel.Filters
                         if (map != null)
                         {
                             if (greaterthan && tier <= map.MapTier)
-                            {
                                 goto End;
-                            }
                             else if (lessthan && tier >= map.MapTier)
-                            {
                                 goto End;
-                            }
                             else if (tier == map.MapTier)
-                            {
                                 goto End;
-                            }
                         }
                     }
                 }
@@ -307,17 +236,11 @@ namespace Procurement.ViewModel.Filters
                     if (ilvl >= 1 && ilvl <= 100)
                     {
                         if (greaterthan && ilvl <= item.ItemLevel)
-                        {
                             goto End;
-                        }
                         else if (lessthan && ilvl >= item.ItemLevel)
-                        {
                             goto End;
-                        }
                         else if (ilvl == item.ItemLevel)
-                        {
                             goto End;
-                        }
                     }
                 }
                 

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -53,7 +53,6 @@ namespace Procurement.ViewModel.Filters
             int count = 0;
 
             var gear = item as Gear;
-            var gem = item as Gem;
             var map = item as Map;
 
             foreach (var splitword in words)
@@ -168,7 +167,7 @@ namespace Procurement.ViewModel.Filters
                     }
                 }
 
-                if ((gem != null || gear != null) && item.Requirements != null)
+                if ((item is Gem || gear != null) && item.Requirements != null)
                 {
                     string reqtext = "Requires ";
                     int reqcount = 1;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -143,6 +143,10 @@ namespace Procurement.ViewModel.Filters
                 if (item.EnchantMods.Any(x => x.ToLowerInvariant().Contains(word)))
                     goto End;
 
+            if (item.UtilityMods != null && item.UtilityMods.Count > 0)
+                if (item.UtilityMods.Any(x => x.ToLowerInvariant().Contains(word)))
+                    goto End;
+
             if (item.FlavourText != null)
                 if (item.FlavourText.Any(x => x.ToLowerInvariant().Contains(word)))
                     goto End;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -27,7 +27,7 @@ namespace Procurement.ViewModel.Filters
 
         public string Help
         {
-            get { return "Matches user search on name/typeline and geartype"; }
+            get { return "Matches user search on name/typeline, geartype, mods and texts"; }
         }
 
         public bool Applicable(Item item)
@@ -37,6 +37,48 @@ namespace Procurement.ViewModel.Filters
 
             if (item.TypeLine.ToLowerInvariant().Contains(filter.ToLowerInvariant()) || item.Name.ToLowerInvariant().Contains(filter.ToLowerInvariant()) || containsMatchedCosmeticMod(item) || isMatchedGear(item))
                 return true;
+
+            if (item.Explicitmods != null)
+                foreach (var mod in item.Explicitmods)
+                    if (mod.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                        return true;
+
+            if (item.Implicitmods != null)
+                foreach (var mod in item.Implicitmods)
+                    if (mod.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                        return true;
+
+            if (item.FracturedMods != null)
+                foreach (var mod in item.FracturedMods)
+                    if (mod.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                        return true;
+
+            if (item.CraftedMods != null)
+                foreach (var mod in item.CraftedMods)
+                    if (mod.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                        return true;
+
+            if (item.EnchantMods != null)
+                foreach (var mod in item.EnchantMods)
+                    if (mod.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                        return true;
+
+            if (item.FlavourText != null)
+                foreach (var text in item.FlavourText)
+                    if (text.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                        return true;
+
+            if (item.DescrText != null)
+                if (item.DescrText.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                    return true;
+
+            if (item.SecDescrText != null)
+                if (item.SecDescrText.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                    return true;
+
+            if (item.ProphecyText != null)
+                if (item.ProphecyText.ToLowerInvariant().Contains(filter.ToLowerInvariant()))
+                    return true;
 
             var gear = item as Gear;
 

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -49,6 +49,7 @@ namespace Procurement.ViewModel.Filters
             int count = 0;
             
             var gear = item as Gear;
+            var gem = item as Gem;
 
             foreach (var splitword in words)
             {
@@ -150,18 +151,18 @@ namespace Procurement.ViewModel.Filters
                     }
                 }
 
-                if (gear != null && gear.Requirements != null)
+                if ((gem != null || gear != null) && item.Requirements != null)
                 {
                     string reqtext = "Requires ";
                     int reqcount = 1;
-                    foreach (var requirement in gear.Requirements)
+                    foreach (var requirement in item.Requirements)
                     {
                         if (requirement.NameFirst)
                             reqtext += requirement.Name + " " + requirement.Value;
                         else
                             reqtext += requirement.Value + " " + requirement.Name;
 
-                        if (reqcount < gear.Requirements.Count)
+                        if (reqcount < item.Requirements.Count)
                         {
                             reqtext += ", ";
                             reqcount++;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -55,6 +55,7 @@ namespace Procurement.ViewModel.Filters
         {
             var gear = item as Gear;
             var map = item as Map;
+            var gem = item as Gem;
 
             bool dontmatch = false;
 
@@ -277,7 +278,7 @@ namespace Procurement.ViewModel.Filters
                     goto End;
             }
 
-            if (!item.Corrupted && (item is Gem || (ItemIsGearOrMap && (!gear?.GearType.Equals(GearType.Flask) ?? true))))
+            if (!item.Corrupted && (gem != null || (ItemIsGearOrMap && (!gear?.GearType.Equals(GearType.Flask) ?? true))))
             {
                 text = "uncorrupted";
                 if (text.StartsWith(word))
@@ -326,11 +327,22 @@ namespace Procurement.ViewModel.Filters
                     goto End;
             }
 
-            if (item is Gem)
+            if (gem != null)
             {
                 text = "gems";
                 if (text.Contains(word))
                     goto End;
+
+                if (gem.HasExperience)
+                {
+                    text = gem.ExperienceNumerator.ToString();
+                    if (text.Contains(word))
+                        goto End;
+
+                    text = gem.ExperienceDenominator.ToString();
+                    if (text.Contains(word))
+                        goto End;
+                }
             }
 
             if ((gear == null && item.StackSize > 0) || item is Incubator)

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -12,14 +12,10 @@ namespace Procurement.ViewModel.Filters
             get { return FilterGroup.Default; }
         }
 
-        private string filter;
-        private bool OrMatch;
-        private bool HasSpace;
-        public UserSearchFilter(string filter, bool OrMatch, bool HasSpace)
+        private List<List<string>> filterlists;
+        public UserSearchFilter(List<List<string>> filterlists)
         {
-            this.filter = filter;
-            this.OrMatch = OrMatch;
-            this.HasSpace = HasSpace;
+            this.filterlists = filterlists;
         }
         public bool CanFormCategory
         {
@@ -38,51 +34,13 @@ namespace Procurement.ViewModel.Filters
 
         public bool Applicable(Item item)
         {
-            if (string.IsNullOrEmpty(filter))
+            if (!(filterlists?.Count > 0))
                 return false;
 
-            if (!OrMatch)
+            foreach (var list in filterlists)
             {
-                if (!HasSpace)
-                {
-                    if (hasMatch(filter.Trim('"'), item))
-                        return true;
-                }
-                else
-                {
-                    var words = filter.Split('"')
-                                         .Select((element, index) => index % 2 == 0
-                                             ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                                             : new string[] { element })
-                                         .SelectMany(element => element).ToList();
-
-                    if (words.All(x => hasMatch(x, item)))
-                        return true;
-                }
-            }
-            else
-            {
-                var words = filter.Split('|');
-
-                foreach (var word in words)
-                {
-                    if (!HasSpace)
-                    {
-                        if (hasMatch(word.Trim('"'), item))
-                            return true;
-                    }
-                    else
-                    {
-                        var words1 = word.Split('"')
-                                             .Select((element, index) => index % 2 == 0
-                                                 ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                                                 : new string[] { element })
-                                             .SelectMany(element => element).ToList();
-
-                        if (words1.All(x => hasMatch(x, item)))
-                            return true;
-                    }
-                }
+                if (list?.Count > 0 && list.All(x => hasMatch(x, item)))
+                    return true;
             }
 
             var gear = item as Gear;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -37,7 +37,14 @@ namespace Procurement.ViewModel.Filters
             if (string.IsNullOrEmpty(filter))
                 return false;
 
-            var words = filter.ToLowerInvariant().Split('"')
+            string filterlow = filter.ToLowerInvariant();
+
+            filterlow = filterlow.Replace(" -\"", " \"-");
+
+            if (filterlow.StartsWith("-\""))
+                filterlow = "\"-" + filterlow.Substring(2);
+
+            var words = filterlow.Split('"')
                 .Select((element, index) => index % 2 == 0
                     ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
                     : new string[] { element })

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -130,21 +130,59 @@ namespace Procurement.ViewModel.Filters
                             matched = true;
                     }
                 }
-
-                int number;
-                int.TryParse(word, out number);
-
-                if (item.ItemLevel > 0 && !matched)
-                    if (number == item.ItemLevel)
-                        matched = true;
-
-                if (item.StackSize > 0 && !matched)
-                    if (number == item.StackSize)
-                        matched = true;
-
-                if (item.MaxStackSize > 0 && !matched)
-                    if (number == item.MaxStackSize)
-                        matched = true;
+                
+                if (!matched)
+                {
+                    string text = null;
+                    if (item.EnchantMods != null && item.EnchantMods.Count() > 0)
+                    {
+                        text = "enchanted";
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                    if (item.CraftedMods != null && item.CraftedMods.Count() > 0 && !matched)
+                    {
+                        text = "crafted";
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                    if (item.Fractured && !matched)
+                    {
+                        text = "fractured";
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                    if (item.Corrupted && !matched)
+                    {
+                        text = "corrupted";
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                    if (!item.Identified && !matched)
+                    {
+                        text = "unidentified";
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                    if (item.ItemLevel > 0 && !matched)
+                    {
+                        text = item.ItemLevel.ToString();
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                    if (item.StackSize > 0 && !matched)
+                    {
+                        text = item.StackSize.ToString();
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                    if (item.MaxStackSize > 0 && !matched)
+                    {
+                        text = item.MaxStackSize.ToString();
+                        if (text.Contains(word))
+                            matched = true;
+                    }
+                }
 
                 if (word.StartsWith("tier:") && !matched)
                 {
@@ -156,7 +194,8 @@ namespace Procurement.ViewModel.Filters
                     {
                         word = word.Remove(word.Length - 1);
                         greaterthan = true;
-                    } else if (word.EndsWith("-"))
+                    }
+                    else if (word.EndsWith("-"))
                     {
                         word = word.Remove(word.Length - 1);
                         lessthan = true;
@@ -186,7 +225,8 @@ namespace Procurement.ViewModel.Filters
                     {
                         word = word.Remove(word.Length - 1);
                         greaterthan = true;
-                    } else if (word.EndsWith("-"))
+                    }
+                    else if (word.EndsWith("-"))
                     {
                         word = word.Remove(word.Length - 1);
                         lessthan = true;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -196,8 +196,10 @@ namespace Procurement.ViewModel.Filters
             {
                 List<string> inctext = new List<string>();
 
-                inctext.Add(item.IncubatedDetails.Progress.ToString());
-                inctext.Add(item.IncubatedDetails.Total.ToString());
+                inctext.Add($"{item.IncubatedDetails.Progress}");
+                inctext.Add($"{item.IncubatedDetails.Total}");
+                inctext.Add($"{item.IncubatedDetails.Progress:n0}");
+                inctext.Add($"{item.IncubatedDetails.Total:n0}");
                 inctext.Add($"Incubating {item.IncubatedDetails.Name}");
                 inctext.Add($"Level {item.IncubatedDetails.Level}+ Monster Kills");
 
@@ -335,12 +337,14 @@ namespace Procurement.ViewModel.Filters
 
                 if (gem.HasExperience)
                 {
-                    text = gem.ExperienceNumerator.ToString();
-                    if (text.Contains(word))
-                        goto End;
+                    List<string> exptext = new List<string>();
 
-                    text = gem.ExperienceDenominator.ToString();
-                    if (text.Contains(word))
+                    exptext.Add($"{gem.ExperienceNumerator}");
+                    exptext.Add($"{gem.ExperienceDenominator}");
+                    exptext.Add($"{gem.ExperienceNumerator:n0}");
+                    exptext.Add($"{gem.ExperienceDenominator:n0}");
+
+                    if (exptext.Any(x => x.ToLowerInvariant().Contains(word)))
                         goto End;
                 }
             }

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -167,7 +167,16 @@ namespace Procurement.ViewModel.Filters
                     if (property.DisplayMode == 0)
                     {
                         if (property.Values.Count == 0)
-                            proptext = property.Name;
+                        {
+                            if (item is Resonator && property.Name.StartsWith("Requires <unmet>{"))
+                            {
+                                proptext = "Requires " + property.Name[17].ToString() + property.Name.Substring(19);
+                            }
+                            else
+                            {
+                                proptext = property.Name;
+                            }
+                        }
                         else
                         {
                             proptext = property.Name + ":";

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -56,7 +56,6 @@ namespace Procurement.ViewModel.Filters
 
                 if (item.TypeLine.ToLowerInvariant().Contains(word) || item.Name.ToLowerInvariant().Contains(word))
                 {
-                    count++;
                     goto End;
                 }
 
@@ -66,7 +65,6 @@ namespace Procurement.ViewModel.Filters
                     {
                         if (mod.ToLowerInvariant().Contains(word))
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -78,7 +76,6 @@ namespace Procurement.ViewModel.Filters
                     {
                         if (mod.ToLowerInvariant().Contains(word))
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -90,7 +87,6 @@ namespace Procurement.ViewModel.Filters
                     {
                         if (mod.ToLowerInvariant().Contains(word))
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -102,7 +98,6 @@ namespace Procurement.ViewModel.Filters
                     {
                         if (mod.ToLowerInvariant().Contains(word))
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -114,7 +109,6 @@ namespace Procurement.ViewModel.Filters
                     {
                         if (mod.ToLowerInvariant().Contains(word))
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -126,7 +120,6 @@ namespace Procurement.ViewModel.Filters
                     {
                         if (flavourtext.ToLowerInvariant().Contains(word))
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -136,7 +129,6 @@ namespace Procurement.ViewModel.Filters
                 {
                     if (item.DescrText.ToLowerInvariant().Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -145,7 +137,6 @@ namespace Procurement.ViewModel.Filters
                 {
                     if (item.SecDescrText.ToLowerInvariant().Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -154,7 +145,6 @@ namespace Procurement.ViewModel.Filters
                 {
                     if (item.ProphecyText.ToLowerInvariant().Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -187,7 +177,6 @@ namespace Procurement.ViewModel.Filters
 
                         if (rarity.Contains(word))
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -199,7 +188,6 @@ namespace Procurement.ViewModel.Filters
                     text = "enchanted";
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -208,7 +196,6 @@ namespace Procurement.ViewModel.Filters
                     text = "crafted";
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -217,7 +204,6 @@ namespace Procurement.ViewModel.Filters
                     text = "fractured";
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -226,7 +212,6 @@ namespace Procurement.ViewModel.Filters
                     text = "corrupted";
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -235,7 +220,6 @@ namespace Procurement.ViewModel.Filters
                     text = "unidentified";
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -244,7 +228,6 @@ namespace Procurement.ViewModel.Filters
                     text = item.ItemLevel.ToString();
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -253,7 +236,6 @@ namespace Procurement.ViewModel.Filters
                     text = item.StackSize.ToString();
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -262,7 +244,6 @@ namespace Procurement.ViewModel.Filters
                     text = item.MaxStackSize.ToString();
                     if (text.Contains(word))
                     {
-                        count++;
                         goto End;
                     }
                 }
@@ -292,17 +273,14 @@ namespace Procurement.ViewModel.Filters
                         {
                             if (greaterthan && tier <= map.MapTier)
                             {
-                                count++;
                                 goto End;
                             }
                             else if (lessthan && tier >= map.MapTier)
                             {
-                                count++;
                                 goto End;
                             }
                             else if (tier == map.MapTier)
                             {
-                                count++;
                                 goto End;
                             }
                         }
@@ -330,17 +308,14 @@ namespace Procurement.ViewModel.Filters
                     {
                         if (greaterthan && ilvl <= item.ItemLevel)
                         {
-                            count++;
                             goto End;
                         }
                         else if (lessthan && ilvl >= item.ItemLevel)
                         {
-                            count++;
                             goto End;
                         }
                         else if (ilvl == item.ItemLevel)
                         {
-                            count++;
                             goto End;
                         }
                     }
@@ -352,8 +327,8 @@ namespace Procurement.ViewModel.Filters
                 continue;
 
                 End:
-                    if (dontmatch)
-                        count--;
+                    if (!dontmatch)
+                        count++;
             }
 
             if (words.Count() == count)

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -72,8 +72,8 @@ namespace Procurement.ViewModel.Filters
                         goto End;
 
                 if (gear != null)
-                        if (gear.GearType.ToString().ToLowerInvariant().Contains(word))
-                            goto End;
+                    if (gear.GearType.ToString().ToLowerInvariant().Contains(word))
+                        goto End;
 
                 if (item.Explicitmods != null)
                     foreach (var mod in item.Explicitmods)

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -35,7 +35,7 @@ namespace Procurement.ViewModel.Filters
             if (string.IsNullOrEmpty(filter))
                 return false;
 
-            if (item.TypeLine.ToLower().Contains(filter.ToLower()) || item.Name.ToLower().Contains(filter.ToLower()) || containsMatchedCosmeticMod(item) || isMatchedGear(item))
+            if (item.TypeLine.ToLowerInvariant().Contains(filter.ToLowerInvariant()) || item.Name.ToLowerInvariant().Contains(filter.ToLowerInvariant()) || containsMatchedCosmeticMod(item) || isMatchedGear(item))
                 return true;
 
             var gear = item as Gear;
@@ -48,7 +48,7 @@ namespace Procurement.ViewModel.Filters
 
         private bool containsMatchedCosmeticMod(Item item)
         {
-            return item.Microtransactions.Any(x => x.ToLower().Contains(filter.ToLower()));
+            return item.Microtransactions.Any(x => x.ToLowerInvariant().Contains(filter.ToLowerInvariant()));
         }
 
         private bool isMatchedGear(Item item)
@@ -58,7 +58,7 @@ namespace Procurement.ViewModel.Filters
             if (gear == null)
                 return false;
 
-            return gear.GearType.ToString().ToLower().Contains(filter.ToLower());
+            return gear.GearType.ToString().ToLowerInvariant().Contains(filter.ToLowerInvariant());
         }
     }
 }

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -176,7 +176,7 @@ namespace Procurement.ViewModel.Filters
                     }
                 }
 
-                if (word.StartsWith("ilvl:") && !matched)
+                if (word.StartsWith("ilvl:") && item.ItemLevel > 0 && !matched)
                 {
                     int ilvl;
                     bool greaterthan = false;

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -102,7 +102,7 @@ namespace Procurement.ViewModel.Filters
                     if (cardtext.ToLowerInvariant().Contains(word))
                         goto End;
 
-                    if (colortext.Any(x => x.ToLowerInvariant().Contains(word)))
+                    if (colortext.Any(x => x.Contains(word)))
                         goto End;
                 }
                 else if (item.Explicitmods.Any(x => x.ToLowerInvariant().Contains(word)))

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -322,9 +322,12 @@ namespace Procurement.ViewModel.Filters
                 }
                 
                 if (dontmatch)
+                {
                     count++;
-
-                continue;
+                    continue;
+                }
+                
+                break;
 
                 End:
                     if (!dontmatch)

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Procurement.ViewModel.Filters
 {
@@ -39,361 +40,427 @@ namespace Procurement.ViewModel.Filters
 
             string filterlow = filter.ToLowerInvariant();
 
+            filterlow = Regex.Replace(filterlow, @"\s+", " ");
+
+            filterlow = filterlow.Replace(" or ", "|");
+
+            if (filterlow.EndsWith("|"))
+                filterlow = filterlow.Remove(filterlow.Length - 1);
+
+            filterlow = filterlow.Replace(" not ", " -");
+
+            if (filterlow.StartsWith("not "))
+                filterlow = "-" + filterlow.Substring(4);
+
             filterlow = filterlow.Replace(" -\"", " \"-");
 
             if (filterlow.StartsWith("-\""))
                 filterlow = "\"-" + filterlow.Substring(2);
 
-            var words = filterlow.Split('"')
-                .Select((element, index) => index % 2 == 0
-                    ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                    : new string[] { element })
-                .SelectMany(element => element).ToList();
+            if (!filterlow.Contains('|'))
+            {
+                if (!filterlow.Contains(' '))
+                {
+                    if (hasMatch(filterlow.Trim('"'), item))
+                        return true;
+                }
+                else
+                {
+                    var words = filterlow.Split('"')
+                                         .Select((element, index) => index % 2 == 0
+                                             ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                                             : new string[] { element })
+                                         .SelectMany(element => element).ToList();
 
-            int count = 0;
+                    int count = 0;
 
+                    foreach (var word in words)
+                    {
+                        if (hasMatch(word, item))
+                            count++;
+                        else
+                            break;
+                    }
+
+                    if (count == words.Count)
+                        return true;
+                }
+            }
+            else
+            {
+                filterlow = filterlow.Replace(" |", "|").Replace("| ", "|");
+
+                var words = filterlow.Split('|');
+
+                foreach (var word in words)
+                {
+                    if (!word.Contains(' '))
+                    {
+                        if (hasMatch(word.Trim('"'), item))
+                            return true;
+                    }
+                    else
+                    {
+                        var words1 = word.Split('"')
+                                             .Select((element, index) => index % 2 == 0
+                                                 ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                                                 : new string[] { element })
+                                             .SelectMany(element => element).ToList();
+
+                        int count1 = 0;
+
+                        foreach (var word1 in words1)
+                        {
+                            if (hasMatch(word1, item))
+                                count1++;
+                            else
+                                break;
+                        }
+
+                        if (count1 == words1.Count)
+                            return true;
+                    }
+                }
+            }
+
+            var gear = item as Gear;
+
+            if (gear != null && gear.SocketedItems.Any(x => Applicable(x)))
+                return true;
+
+            return false;
+        }
+
+        private bool hasMatch(string word, Item item)
+        {
             var gear = item as Gear;
             var map = item as Map;
 
-            foreach (var splitword in words)
+            bool dontmatch = false;
+
+            if (word.StartsWith("-"))
             {
-                var word = splitword;
+                word = word.Remove(0, 1);
 
-                bool dontmatch = false;
-
-                if (word.StartsWith("-"))
-                {
-                    word = word.Remove(0, 1);
-
-                    if (string.IsNullOrEmpty(word))
-                        goto End;
-
-                    dontmatch = true;
-                }
-
-                if (item.TypeLine.ToLowerInvariant().Contains(word))
+                if (string.IsNullOrEmpty(word))
                     goto End;
 
-                if (item.Name.ToLowerInvariant().Contains(word))
-                    goto End;
+                dontmatch = true;
+            }
+
+            if (item.TypeLine.ToLowerInvariant().Contains(word))
+                goto End;
+
+            if (item.Name.ToLowerInvariant().Contains(word))
+                goto End;
                     
-                if (item.Microtransactions != null)
-                    if (item.Microtransactions.Any(x => x.ToLowerInvariant().Contains(word)))
+            if (item.Microtransactions != null)
+                if (item.Microtransactions.Any(x => x.ToLowerInvariant().Contains(word)))
+                    goto End;
+
+            if (gear != null)
+                if (gear.GearType.ToString().ToLowerInvariant().Contains(word))
+                    goto End;
+
+            if (item.Explicitmods != null)
+                foreach (var mod in item.Explicitmods)
+                    if (mod.ToLowerInvariant().Contains(word))
                         goto End;
 
-                if (gear != null)
-                    if (gear.GearType.ToString().ToLowerInvariant().Contains(word))
+            if (item.Implicitmods != null)
+                foreach (var mod in item.Implicitmods)
+                    if (mod.ToLowerInvariant().Contains(word))
                         goto End;
 
-                if (item.Explicitmods != null)
-                    foreach (var mod in item.Explicitmods)
-                        if (mod.ToLowerInvariant().Contains(word))
-                            goto End;
-
-                if (item.Implicitmods != null)
-                    foreach (var mod in item.Implicitmods)
-                        if (mod.ToLowerInvariant().Contains(word))
-                            goto End;
-
-                if (item.FracturedMods != null)
-                    foreach (var mod in item.FracturedMods)
-                        if (mod.ToLowerInvariant().Contains(word))
-                            goto End;
-
-                if (item.CraftedMods != null)
-                    foreach (var mod in item.CraftedMods)
-                        if (mod.ToLowerInvariant().Contains(word))
-                            goto End;
-
-                if (item.EnchantMods != null)
-                    foreach (var mod in item.EnchantMods)
-                        if (mod.ToLowerInvariant().Contains(word))
-                            goto End;
-
-                if (item.FlavourText != null)
-                    foreach (var flavourtext in item.FlavourText)
-                        if (flavourtext.ToLowerInvariant().Contains(word))
-                            goto End;
-
-                if (item.DescrText != null)
-                    if (item.DescrText.ToLowerInvariant().Contains(word))
+            if (item.FracturedMods != null)
+                foreach (var mod in item.FracturedMods)
+                    if (mod.ToLowerInvariant().Contains(word))
                         goto End;
 
-                if (item.SecDescrText != null)
-                    if (item.SecDescrText.ToLowerInvariant().Contains(word))
+            if (item.CraftedMods != null)
+                foreach (var mod in item.CraftedMods)
+                    if (mod.ToLowerInvariant().Contains(word))
                         goto End;
 
-                if (item.ProphecyText != null)
-                    if (item.ProphecyText.ToLowerInvariant().Contains(word))
+            if (item.EnchantMods != null)
+                foreach (var mod in item.EnchantMods)
+                    if (mod.ToLowerInvariant().Contains(word))
                         goto End;
 
-                if (item.Properties != null)
+            if (item.FlavourText != null)
+                foreach (var flavourtext in item.FlavourText)
+                    if (flavourtext.ToLowerInvariant().Contains(word))
+                        goto End;
+
+            if (item.DescrText != null)
+                if (item.DescrText.ToLowerInvariant().Contains(word))
+                    goto End;
+
+            if (item.SecDescrText != null)
+                if (item.SecDescrText.ToLowerInvariant().Contains(word))
+                    goto End;
+
+            if (item.ProphecyText != null)
+                if (item.ProphecyText.ToLowerInvariant().Contains(word))
+                    goto End;
+
+            if (item.Properties != null)
+            {
+                foreach (var property in item.Properties)
                 {
-                    foreach (var property in item.Properties)
+                    string proptext = null;
+                    if (property.DisplayMode == 0)
                     {
-                        string proptext = null;
-                        if (property.DisplayMode == 0)
+                        if (property.Values.Count == 0)
+                            proptext = property.Name;
+                        else
                         {
-                            if (property.Values.Count == 0)
-                                proptext = property.Name;
-                            else
+                            proptext = property.Name + ":";
+                            for (int i = 0; i < property.Values.Count; i++)
                             {
-                                proptext = property.Name + ":";
-                                for (int i = 0; i < property.Values.Count; i++)
-                                {
-                                    proptext += " " + property.Values[i].Item1;
-                                    if (i != property.Values.Count - 1)
-                                        proptext += ", ";
-                                }
+                                proptext += " " + property.Values[i].Item1;
+                                if (i != property.Values.Count - 1)
+                                    proptext += ", ";
                             }
                         }
-                        else if (property.DisplayMode == 1)
-                        {
-                            proptext = property.Values[0].Item1 + " " + property.Name;
-                        }
-                        else if (property.DisplayMode == 3)
-                        {
-                            var parts = property.Name.Split('%');
-
-                            proptext += parts[0] + property.Values[0].Item1 + parts[1].Substring(1);
-
-                            if (property.Values.Count > 1)
-                                proptext += property.Values[1].Item1 + parts[2].Substring(1);
-                        }
-
-                        if (proptext != null)
-                            if (proptext.ToLowerInvariant().Contains(word))
-                                goto End;
                     }
-                }
-
-                if ((item is Gem || gear != null || item is AbyssJewel) && item.Requirements != null)
-                {
-                    string reqtext = "Requires ";
-                    int reqcount = 1;
-                    foreach (var requirement in item.Requirements)
+                    else if (property.DisplayMode == 1)
                     {
-                        if (requirement.NameFirst)
-                            reqtext += requirement.Name + " " + requirement.Value;
-                        else
-                            reqtext += requirement.Value + " " + requirement.Name;
-
-                        if (reqcount < item.Requirements.Count)
-                        {
-                            reqtext += ", ";
-                            reqcount++;
-                        }
+                        proptext = property.Values[0].Item1 + " " + property.Name;
                     }
-                    if (reqtext.ToLowerInvariant().Contains(word))
-                        goto End;
-                }
+                    else if (property.DisplayMode == 3)
+                    {
+                        var parts = property.Name.Split('%');
 
-                if (item.IncubatedDetails != null)
-                {
-                    List<string> inctexts = new List<string>();
+                        proptext += parts[0] + property.Values[0].Item1 + parts[1].Substring(1);
 
-                    inctexts.Add(item.IncubatedDetails.Progress.ToString());
-                    inctexts.Add(item.IncubatedDetails.Total.ToString());
-                    inctexts.Add($"Incubating {item.IncubatedDetails.Name}");
-                    inctexts.Add($"Level {item.IncubatedDetails.Level}+ Monster Kills");
+                        if (property.Values.Count > 1)
+                            proptext += property.Values[1].Item1 + parts[2].Substring(1);
+                    }
 
-                    foreach (string inctext in inctexts)
-                        if (inctext.ToLowerInvariant().Contains(word))
+                    if (proptext != null)
+                        if (proptext.ToLowerInvariant().Contains(word))
                             goto End;
                 }
+            }
 
-                string text = "";
+            if ((item is Gem || gear != null || item is AbyssJewel) && item.Requirements != null)
+            {
+                string reqtext = "Requires ";
+                int reqcount = 1;
+                foreach (var requirement in item.Requirements)
+                {
+                    if (requirement.NameFirst)
+                        reqtext += requirement.Name + " " + requirement.Value;
+                    else
+                        reqtext += requirement.Value + " " + requirement.Name;
 
-                if (map != null || item is AbyssJewel || item is FullBestiaryOrb)
+                    if (reqcount < item.Requirements.Count)
+                    {
+                        reqtext += ", ";
+                        reqcount++;
+                    }
+                }
+                if (reqtext.ToLowerInvariant().Contains(word))
+                    goto End;
+            }
+
+            if (item.IncubatedDetails != null)
+            {
+                List<string> inctexts = new List<string>();
+
+                inctexts.Add(item.IncubatedDetails.Progress.ToString());
+                inctexts.Add(item.IncubatedDetails.Total.ToString());
+                inctexts.Add($"Incubating {item.IncubatedDetails.Name}");
+                inctexts.Add($"Level {item.IncubatedDetails.Level}+ Monster Kills");
+
+                foreach (string inctext in inctexts)
+                    if (inctext.ToLowerInvariant().Contains(word))
+                        goto End;
+            }
+
+            string text = "";
+
+            if (map != null || item is AbyssJewel || item is FullBestiaryOrb)
+            {
+                text = "rarity: " + item.Rarity.ToString().ToLowerInvariant();
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (gear != null)
+                if (!gear.GearType.Equals(GearType.Unknown)
+                 && !gear.GearType.Equals(GearType.DivinationCard)
+                 && !gear.GearType.Equals(GearType.Breachstone))
                 {
                     text = "rarity: " + item.Rarity.ToString().ToLowerInvariant();
                     if (text.Contains(word))
                         goto End;
                 }
 
-                if (gear != null)
-                    if (!gear.GearType.Equals(GearType.Unknown)
-                     && !gear.GearType.Equals(GearType.DivinationCard)
-                     && !gear.GearType.Equals(GearType.Breachstone))
-                    {
-                        text = "rarity: " + item.Rarity.ToString().ToLowerInvariant();
-                        if (text.Contains(word))
-                            goto End;
-                    }
-
-                if (item.ItemLevel > 0)
-                {
-                    text = "item level: " + item.ItemLevel.ToString();
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (item.Implicitmods != null)
-                {
-                    if (item.Implicitmods.Count == 1)
-                    {
-                        text = "implicit";
-                        if (text.Contains(word))
-                            goto End;
-                    }
-                    else if (item.Implicitmods.Count == 2)
-                    {
-                        text = "two-implicit";
-                        if (text.Contains(word))
-                            goto End;
-                        text = "double implicit";
-                        if (text.Contains(word))
-                            goto End;
-                    }
-                }
-
-                if (item.IsMirrored)
-                {
-                    text = "mirrored";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (item.EnchantMods != null && item.EnchantMods.Count > 0)
-                {
-                    text = "enchanted";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (item.CraftedMods != null && item.CraftedMods.Count > 0)
-                {
-                    text = "crafted";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (item.Fractured)
-                {
-                    text = "fractured";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (item.Corrupted)
-                {
-                    text = "corrupted";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (!item.Identified)
-                {
-                    text = "unidentified";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (item is FullBestiaryOrb)
-                {
-                    text = "captured beast";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (item is Gem)
-                {
-                    text = "gem";
-                    if (text.Contains(word))
-                        goto End;
-                }
-
-                if (gear != null)
-                    if (gear.GearType.Equals(GearType.Unknown))
-                        if (gear.TypeLine.StartsWith("Sacrifice at ")
-                         || gear.TypeLine.StartsWith("Mortal ")
-                         || gear.TypeLine.StartsWith("Fragment of the ")
-                         || gear.TypeLine.EndsWith(" Key"))
-                        {
-                            text = "map fragment";
-                            if (text.Contains(word))
-                                goto End;
-                        }
-
-                if (word.StartsWith("tier:") && map != null)
-                {
-                    int tier;
-                    bool greaterthan = false;
-                    bool lessthan = false;
-                    word = word.Remove(0, 5);
-                    if (word.EndsWith("+"))
-                    {
-                        word = word.Remove(word.Length - 1);
-                        greaterthan = true;
-                    }
-                    else if (word.EndsWith("-"))
-                    {
-                        word = word.Remove(word.Length - 1);
-                        lessthan = true;
-                    }
-
-                    int.TryParse(word, out tier);
-                    if (tier >= 1 && tier <= 16)
-                    {
-                        if (greaterthan && tier <= map.MapTier)
-                            goto End;
-                        else if (lessthan && tier >= map.MapTier)
-                            goto End;
-                        else if (tier == map.MapTier)
-                            goto End;
-                    }
-                }
-
-                if (word.StartsWith("ilvl:") && item.ItemLevel > 0)
-                {
-                    int ilvl;
-                    bool greaterthan = false;
-                    bool lessthan = false;
-                    word = word.Remove(0, 5);
-                    if (word.EndsWith("+"))
-                    {
-                        word = word.Remove(word.Length - 1);
-                        greaterthan = true;
-                    }
-                    else if (word.EndsWith("-"))
-                    {
-                        word = word.Remove(word.Length - 1);
-                        lessthan = true;
-                    }
-                    int.TryParse(word, out ilvl);
-                    if (ilvl >= 1 && ilvl <= 100)
-                    {
-                        if (greaterthan && ilvl <= item.ItemLevel)
-                            goto End;
-                        else if (lessthan && ilvl >= item.ItemLevel)
-                            goto End;
-                        else if (ilvl == item.ItemLevel)
-                            goto End;
-                    }
-                }
-                
-                if (dontmatch)
-                {
-                    count++;
-                    continue;
-                }
-                
-                break;
-
-                End:
-                    if (!dontmatch)
-                        count++;
-                    else
-                        break;
+            if (item.ItemLevel > 0)
+            {
+                text = "item level: " + item.ItemLevel.ToString();
+                if (text.Contains(word))
+                    goto End;
             }
 
-            if (words.Count == count)
-                return true;
+            if (item.Implicitmods != null)
+            {
+                if (item.Implicitmods.Count == 1)
+                {
+                    text = "implicit";
+                    if (text.Contains(word))
+                        goto End;
+                }
+                else if (item.Implicitmods.Count == 2)
+                {
+                    text = "two-implicit";
+                    if (text.Contains(word))
+                        goto End;
+                    text = "double implicit";
+                    if (text.Contains(word))
+                        goto End;
+                }
+            }
 
-            if (gear != null && gear.SocketedItems.Any(x => Applicable(x)))
-                return true;
+            if (item.IsMirrored)
+            {
+                text = "mirrored";
+                if (text.Contains(word))
+                    goto End;
+            }
 
+            if (item.EnchantMods != null && item.EnchantMods.Count > 0)
+            {
+                text = "enchanted";
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (item.CraftedMods != null && item.CraftedMods.Count > 0)
+            {
+                text = "crafted";
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (item.Fractured)
+            {
+                text = "fractured";
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (item.Corrupted)
+            {
+                text = "corrupted";
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (!item.Identified)
+            {
+                text = "unidentified";
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (item is FullBestiaryOrb)
+            {
+                text = "captured beast";
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (item is Gem)
+            {
+                text = "gem";
+                if (text.Contains(word))
+                    goto End;
+            }
+
+            if (gear != null)
+                if (gear.GearType.Equals(GearType.Unknown))
+                    if (gear.TypeLine.StartsWith("Sacrifice at ")
+                     || gear.TypeLine.StartsWith("Mortal ")
+                     || gear.TypeLine.StartsWith("Fragment of the ")
+                     || gear.TypeLine.EndsWith(" Key"))
+                    {
+                        text = "map fragment";
+                        if (text.Contains(word))
+                            goto End;
+                    }
+
+            if (word.StartsWith("tier:") && map != null)
+            {
+                int tier;
+                bool greaterthan = false;
+                bool lessthan = false;
+                word = word.Remove(0, 5);
+                if (word.EndsWith("+"))
+                {
+                    word = word.Remove(word.Length - 1);
+                    greaterthan = true;
+                }
+                else if (word.EndsWith("-"))
+                {
+                    word = word.Remove(word.Length - 1);
+                    lessthan = true;
+                }
+
+                int.TryParse(word, out tier);
+                if (tier >= 1 && tier <= 16)
+                {
+                    if (greaterthan && tier <= map.MapTier)
+                        goto End;
+                    else if (lessthan && tier >= map.MapTier)
+                        goto End;
+                    else if (tier == map.MapTier)
+                        goto End;
+                }
+            }
+
+            if (word.StartsWith("ilvl:") && item.ItemLevel > 0)
+            {
+                int ilvl;
+                bool greaterthan = false;
+                bool lessthan = false;
+                word = word.Remove(0, 5);
+                if (word.EndsWith("+"))
+                {
+                    word = word.Remove(word.Length - 1);
+                    greaterthan = true;
+                }
+                else if (word.EndsWith("-"))
+                {
+                    word = word.Remove(word.Length - 1);
+                    lessthan = true;
+                }
+                int.TryParse(word, out ilvl);
+                if (ilvl >= 1 && ilvl <= 100)
+                {
+                    if (greaterthan && ilvl <= item.ItemLevel)
+                        goto End;
+                    else if (lessthan && ilvl >= item.ItemLevel)
+                        goto End;
+                    else if (ilvl == item.ItemLevel)
+                        goto End;
+                }
+            }
+                
+            if (dontmatch)
+            {
+                return true;
+            }
+                
             return false;
+
+            End:
+                if (!dontmatch)
+                    return true;
+                else
+                    return false;
         }
     }
 }

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -205,7 +205,7 @@ namespace Procurement.ViewModel.Filters
 
                 string text = "";
 
-                if (map != null)
+                if (map != null || item is AbyssJewel || item is FullBestiaryOrb)
                 {
                     text = "rarity: " + item.Rarity.ToString().ToLowerInvariant();
                     if (text.Contains(word))
@@ -260,6 +260,12 @@ namespace Procurement.ViewModel.Filters
                 if (!item.Identified)
                 {
                     text = "unidentified";
+                    if (text.Contains(word))
+                        goto End;
+                }
+                if (item is FullBestiaryOrb)
+                {
+                    text = "captured beast";
                     if (text.Contains(word))
                         goto End;
                 }

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -1,5 +1,6 @@
 ﻿using POEApi.Model;
 using System.Linq;
+using System;
 
 namespace Procurement.ViewModel.Filters
 {
@@ -37,8 +38,12 @@ namespace Procurement.ViewModel.Filters
 
             if (containsMatchedCosmeticMod(item) || isMatchedGear(item))
                 return true;
-
-            string[] words = filter.ToLowerInvariant().Split(' ');
+            
+            var words = filter.ToLowerInvariant().Split('"')
+                .Select((element, index) => index % 2 == 0
+                    ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                    : new string[] { element })
+                .SelectMany(element => element).ToList();
 
             int count = 0;
 

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -57,9 +57,7 @@ namespace Procurement.ViewModel.Filters
                                          .SelectMany(element => element).ToList();
 
                     if (words.All(x => hasMatch(x, item)))
-                    {
                         return true;
-                    }
                 }
             }
             else

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -206,12 +206,14 @@ namespace Procurement.ViewModel.Filters
                     {
                         var map = item as Map;
                         if (map != null)
+                        {
                             if (greaterthan && tier <= map.MapTier)
                                 matched = true;
                             else if (lessthan && tier >= map.MapTier)
                                 matched = true;
                             else if (tier == map.MapTier)
                                 matched = true;
+                        }
                     }
                 }
 

--- a/Procurement/ViewModel/Filters/UserSearchFilter.cs
+++ b/Procurement/ViewModel/Filters/UserSearchFilter.cs
@@ -49,7 +49,7 @@ namespace Procurement.ViewModel.Filters
                 bool matched = false;
                 bool dontmatch = false;
 
-                if (word.StartsWith("!"))
+                if (word.StartsWith("-"))
                 {
                     dontmatch = true;
                     word = word.Remove(0, 1);

--- a/Procurement/ViewModel/ForumExportVisitors/SingleBuyoutVisitor.cs
+++ b/Procurement/ViewModel/ForumExportVisitors/SingleBuyoutVisitor.cs
@@ -13,7 +13,7 @@ namespace Procurement.ViewModel.ForumExportVisitors
         public SingleBuyoutVisitor()
         {
             tokens = Settings.Buyouts.Keys.GroupBy(k => Settings.Buyouts[k].Buyout)
-                                          .ToDictionary(g => string.Concat("{", g.Key.ToLower(), "}"), g => (IFilter)new BuyoutFilter(g.Key.ToLower()));
+                                          .ToDictionary(g => string.Concat("{", g.Key.ToLowerInvariant(), "}"), g => (IFilter)new BuyoutFilter(g.Key.ToLowerInvariant()));
         }
         public override string Visit(IEnumerable<POEApi.Model.Item> items, string current)
         {

--- a/Procurement/ViewModel/ForumExportVisitors/VisitorBase.cs
+++ b/Procurement/ViewModel/ForumExportVisitors/VisitorBase.cs
@@ -11,17 +11,17 @@ namespace Procurement.ViewModel.ForumExportVisitors
     {
         protected virtual bool buyoutItemsOnlyVisibleInBuyoutsTag
         {
-            get { return Settings.UserSettings.GetEntry("BuyoutItemsOnlyVisibleInBuyoutsTag").ToLower() == "true"; }
+            get { return Settings.UserSettings.GetEntry("BuyoutItemsOnlyVisibleInBuyoutsTag").ToLowerInvariant() == "true"; }
         }
 
         protected virtual bool embedBuyouts
         {
-            get { return Settings.UserSettings.GetEntry("EmbedBuyouts").ToLower() == "true"; }
+            get { return Settings.UserSettings.GetEntry("EmbedBuyouts").ToLowerInvariant() == "true"; }
         }
 
         protected virtual bool onlyDisplayBuyouts
         {
-            get { return Settings.UserSettings.GetEntry("OnlyDisplayBuyouts").ToLower() == "true"; }
+            get { return Settings.UserSettings.GetEntry("OnlyDisplayBuyouts").ToLowerInvariant() == "true"; }
         }
 
         public abstract string Visit(IEnumerable<Item> items, string current);

--- a/Procurement/ViewModel/ItemDisplayViewModel.cs
+++ b/Procurement/ViewModel/ItemDisplayViewModel.cs
@@ -57,7 +57,17 @@ namespace Procurement.ViewModel
                                         : new SolidColorBrush(Colors.Transparent); }
         }
 
-        public bool IsStackSizeVisible => Item?.StackSize > 0;
+        public bool IsFullSetOfCards
+        {
+            get
+            {
+                var gear = Item as Gear;
+
+                return gear != null && gear.GearType == GearType.DivinationCard && gear.MaxStackSize > 0 && gear.StackSize >= gear.MaxStackSize;
+            }
+        }
+
+        public bool IsStackSizeVisible => Item?.StackSize > 0 && !IsFullSetOfCards;
 
         public int StackSize
         {

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -43,6 +43,7 @@ namespace Procurement.ViewModel
         public List<string> CraftedMods { get; set; }
         public List<string> VeiledMods { get; set; }
         public List<string> FracturedMods { get; set; }
+        public List<string> UtilityMods { get; set; }
 
         public bool HasCraftedMods { get; private set; }
         public bool HasVeiledMods { get; private set; }
@@ -116,6 +117,8 @@ namespace Procurement.ViewModel
 
             this.FracturedMods = item.FracturedMods;
 
+            this.UtilityMods = item.UtilityMods;
+            
             SecondaryDescriptionText = item.SecDescrText;
             setTypeSpecificProperties(item);
 
@@ -161,7 +164,7 @@ namespace Procurement.ViewModel
 
             bool HasMods = HasFracturedMods || HasExplicitMods || HasCraftedMods || HasVeiledMods || IsMirrored || IsUnidentified || IsCorrupted;
 
-            if (Properties != null && (HasRequirements || HasEnchantMods || HasImplicitMods || HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            if ((Properties != null || UtilityMods?.Count > 0) && (HasRequirements || HasEnchantMods || HasImplicitMods || HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
             {
                 this.SeparateProperties = true;
             }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -164,7 +164,7 @@ namespace Procurement.ViewModel
 
             bool HasMods = HasFracturedMods || HasExplicitMods || HasCraftedMods || HasVeiledMods || IsMirrored || IsUnidentified || IsCorrupted;
 
-            if ((Properties != null || UtilityMods?.Count > 0) && (HasRequirements || HasEnchantMods || HasImplicitMods || HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            if ((Properties != null || UtilityMods?.Count > 0) && (HasRequirements || HasEnchantMods || HasImplicitMods || HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible || IsDivinationCard))
             {
                 this.SeparateProperties = true;
             }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -128,9 +128,6 @@ namespace Procurement.ViewModel
             if (gem != null)
             {
                 LevelExperienceProgress = gem.LevelExperienceProgress;
-                if (LevelExperienceProgress < 0.01)
-                        LevelExperienceProgress = 0.01; // Make it visible on progress bar
-
                 ExperienceNumbers = $"{gem.ExperienceNumerator:n0}/{gem.ExperienceDenominator:n0}";
             }
 
@@ -142,8 +139,6 @@ namespace Procurement.ViewModel
                 if (Item.IncubatedDetails.Total > 0)
                 {
                     IncubatorProgress = Convert.ToDouble(item.IncubatedDetails.Progress) / Convert.ToDouble(item.IncubatedDetails.Total);
-                    if (IncubatorProgress < 0.01)
-                        IncubatorProgress = 0.01; // Make it visible on progress bar
                 }
             }
 

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -26,6 +26,13 @@ namespace Procurement.ViewModel
         public string DescriptionText { get; private set; }
         public string SecondaryDescriptionText { get; private set; }
         public bool IsCorrupted { get; private set; }
+        public bool IsUnidentified { get; private set; }
+        public bool SeparateProperties { get; private set; }
+        public bool SeparateRequirements { get; private set; }
+        public bool SeparateEnchantMods { get; private set; }
+        public bool SeparateImplicitMods { get; private set; }
+        public bool SeparateMods { get; private set; }
+        public bool SeparateFlavourText { get; private set; }
         public List<string> Microtransactions { get; private set; }
         public bool HasMicrotransactions { get; private set; }
         public List<string> EnchantMods { get; private set; }
@@ -42,7 +49,6 @@ namespace Procurement.ViewModel
         public bool IsProphecy { get; set; }
         public string ProphecyText { get; set; }
         public string ProphecyDifficultyText { get; set; }
-        public bool IsGear { get; set; }
 
         public string ItemLevel { get; set; }
 
@@ -96,6 +102,7 @@ namespace Procurement.ViewModel
             this.DescriptionText = item.DescrText;
 
             this.IsCorrupted = item.Corrupted;
+            this.IsUnidentified = !item.Identified;
 
             this.Microtransactions = item.Microtransactions;
             this.HasMicrotransactions = item.Microtransactions.Count > 0;
@@ -109,11 +116,6 @@ namespace Procurement.ViewModel
 
             SecondaryDescriptionText = item.SecDescrText;
             setTypeSpecificProperties(item);
-
-            if ((item is AbyssJewel || item is FullBestiaryOrb) && item.ItemLevel > 0)
-            {
-                this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
-            }
 
             var gem = Item as Gem;
             if (gem != null)
@@ -141,7 +143,7 @@ namespace Procurement.ViewModel
             this.HasCraftedMods = CraftedMods?.Count > 0;
             this.HasVeiledMods = VeiledMods?.Count > 0;
             this.HasFracturedMods = FracturedMods?.Count > 0;
-            this.HasExplicitMods = ExplicitMods?.Count > 0 || HasFracturedMods || HasCraftedMods || IsMirrored;
+            this.HasExplicitMods = ExplicitMods?.Count > 0;
             this.HasImplicitMods = ImplicitMods?.Count > 0;
             this.HasEnchantMods = item.EnchantMods.Count > 0;
             this.HasRequirements = Requirements?.Count > 0;
@@ -149,6 +151,38 @@ namespace Procurement.ViewModel
             if (item.FlavourText?.Count > 0)
             {
                 this.FlavourText = string.Join("", item.FlavourText);
+            }
+
+            bool HasMods = HasFracturedMods || HasExplicitMods || HasCraftedMods || HasVeiledMods || IsMirrored || IsUnidentified || IsCorrupted;
+
+            if (Properties != null && (HasRequirements || HasEnchantMods || HasImplicitMods || HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            {
+                this.SeparateProperties = true;
+            }
+
+            if (HasRequirements && (HasEnchantMods || HasImplicitMods || HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            {
+                this.SeparateRequirements = true;
+            }
+
+            if (HasEnchantMods && (HasImplicitMods || HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            {
+                this.SeparateEnchantMods = true;
+            }
+
+            if (HasImplicitMods && (HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            {
+                this.SeparateImplicitMods = true;
+            }
+
+            if (HasMods && (FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            {
+                this.SeparateMods = true;
+            }
+
+            if (FlavourText != null && (DescriptionText != null || IsIncubatorProgressVisible))
+            {
+                this.SeparateFlavourText = true;
             }
 
             setProphecyProperties(item);
@@ -188,26 +222,18 @@ namespace Procurement.ViewModel
 
         private void setTypeSpecificProperties(Item item)
         {
-            var gear = item as Gear;
-
-            if (gear != null)
-                setGearProperties(item, gear);
-
-            var gem = item as Gem;
-
-            if (gem != null)
-                this.Requirements = gem.Requirements;
-        }
-
-        private void setGearProperties(Item item, Gear gear)
-        {
-            this.IsGear = true;
-            if (item.ItemLevel > 0)
+            if ((item is Gear | item is AbyssJewel) && item.ItemLevel > 0)
             {
                 this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
+                this.Requirements = item.Requirements;
+                this.ImplicitMods = item.Implicitmods;
             }
-            this.Requirements = gear.Requirements;
-            this.ImplicitMods = gear.Implicitmods;
+
+            if (item is FullBestiaryOrb && item.ItemLevel > 0)
+                this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
+
+            if (item is Gem)
+                this.Requirements = item.Requirements;
         }
     }
 }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -50,6 +50,7 @@ namespace Procurement.ViewModel
         public bool IsProphecy { get; set; }
         public string ProphecyText { get; set; }
         public string ProphecyDifficultyText { get; set; }
+        public bool IsDivinationCard { get; set; }
 
         public string ItemLevel { get; set; }
 
@@ -118,6 +119,10 @@ namespace Procurement.ViewModel
             SecondaryDescriptionText = item.SecDescrText;
             setTypeSpecificProperties(item);
 
+            var gear = Item as Gear;
+
+            this.IsDivinationCard = gear != null && gear.GearType == GearType.DivinationCard;
+
             var gem = Item as Gem;
             if (gem != null)
             {
@@ -144,7 +149,7 @@ namespace Procurement.ViewModel
             this.HasCraftedMods = CraftedMods?.Count > 0;
             this.HasVeiledMods = VeiledMods?.Count > 0;
             this.HasFracturedMods = FracturedMods?.Count > 0;
-            this.HasExplicitMods = ExplicitMods?.Count > 0;
+            this.HasExplicitMods = ExplicitMods?.Count > 0 && !IsDivinationCard;
             this.HasImplicitMods = ImplicitMods?.Count > 0;
             this.HasEnchantMods = item.EnchantMods.Count > 0;
             this.HasRequirements = Requirements?.Count > 0;

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -242,6 +242,8 @@ namespace Procurement.ViewModel
                 this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
             else if (item is Gem)
                 this.Requirements = item.Requirements;
+            else if (item is Map)
+                this.ImplicitMods = item.Implicitmods;
         }
     }
 }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -197,7 +197,10 @@ namespace Procurement.ViewModel
         private void setGearProperties(Item item, Gear gear)
         {
             this.IsGear = true;
-            this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
+            if (item.ItemLevel > 0)
+            {
+                this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
+            }
             this.Requirements = gear.Requirements;
             this.ImplicitMods = gear.Implicitmods;
         }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -235,7 +235,7 @@ namespace Procurement.ViewModel
                 this.ImplicitMods = item.Implicitmods;
             }
 
-            if (item is FullBestiaryOrb && item.ItemLevel > 0)
+            if ((item is FullBestiaryOrb | item is Incubator) && item.ItemLevel > 0)
                 this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
 
             if (item is Gem)

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -70,13 +70,11 @@ namespace Procurement.ViewModel
 
         public double LevelExperienceProgress { get; set; }
 
-        public int ExperienceNumerator { get; }
-        public int ExperienceDenominator { get; }
+        public string ExperienceNumbers { get; }
 
-        public int IncubatorNumerator { get; }
-        public int IncubatorDenominator { get; }
         public double IncubatorProgress { get; }
         public string Incubating { get; set; }
+        public string IncubationNumbers { get; set; }
         public string IncubationLevel { get; set; }
 
         public bool IsIncubatorProgressVisible
@@ -130,19 +128,22 @@ namespace Procurement.ViewModel
             if (gem != null)
             {
                 LevelExperienceProgress = gem.LevelExperienceProgress;
-                ExperienceNumerator = gem.ExperienceNumerator;
-                ExperienceDenominator = gem.ExperienceDenominator;
+                if (LevelExperienceProgress < 0.01)
+                        LevelExperienceProgress = 0.01; // Make it visible on progress bar
+
+                ExperienceNumbers = $"{gem.ExperienceNumerator:n0}/{gem.ExperienceDenominator:n0}";
             }
 
             if (IsIncubatorProgressVisible)
             {
-                IncubatorNumerator = item.IncubatedDetails.Progress;
-                IncubatorDenominator = item.IncubatedDetails.Total;
                 Incubating = $"Incubating {item.IncubatedDetails.Name}";
+                IncubationNumbers = $"{item.IncubatedDetails.Progress:n0}/{item.IncubatedDetails.Total:n0}";
                 IncubationLevel =  $"Level {item.IncubatedDetails.Level}+ Monster Kills";
                 if (Item.IncubatedDetails.Total > 0)
                 {
                     IncubatorProgress = Convert.ToDouble(item.IncubatedDetails.Progress) / Convert.ToDouble(item.IncubatedDetails.Total);
+                    if (IncubatorProgress < 0.01)
+                        IncubatorProgress = 0.01; // Make it visible on progress bar
                 }
             }
 

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -110,6 +110,11 @@ namespace Procurement.ViewModel
             SecondaryDescriptionText = item.SecDescrText;
             setTypeSpecificProperties(item);
 
+            if ((item is AbyssJewel || item is FullBestiaryOrb) && item.ItemLevel > 0)
+            {
+                this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
+            }
+
             var gem = Item as Gem;
             if (gem != null)
             {

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -228,14 +228,14 @@ namespace Procurement.ViewModel
 
         private void setTypeSpecificProperties(Item item)
         {
-            if ((item is Gear | item is AbyssJewel) && item.ItemLevel > 0)
+            if ((item is Gear || item is AbyssJewel) && item.ItemLevel > 0)
             {
                 this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
                 this.Requirements = item.Requirements;
                 this.ImplicitMods = item.Implicitmods;
             }
 
-            if ((item is FullBestiaryOrb | item is Incubator) && item.ItemLevel > 0)
+            if ((item is FullBestiaryOrb || item is Incubator) && item.ItemLevel > 0)
                 this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
 
             if (item is Gem)

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -234,11 +234,9 @@ namespace Procurement.ViewModel
                 this.Requirements = item.Requirements;
                 this.ImplicitMods = item.Implicitmods;
             }
-
-            if ((item is FullBestiaryOrb || item is Incubator) && item.ItemLevel > 0)
+            else if ((item is FullBestiaryOrb || item is Incubator) && item.ItemLevel > 0)
                 this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
-
-            if (item is Gem)
+            else if (item is Gem)
                 this.Requirements = item.Requirements;
         }
     }

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -32,6 +32,7 @@ namespace Procurement.ViewModel
         public bool SeparateEnchantMods { get; private set; }
         public bool SeparateImplicitMods { get; private set; }
         public bool SeparateMods { get; private set; }
+        public bool SeparateMicrotransactions { get; private set; }
         public bool SeparateFlavourText { get; private set; }
         public List<string> Microtransactions { get; private set; }
         public bool HasMicrotransactions { get; private set; }
@@ -155,29 +156,34 @@ namespace Procurement.ViewModel
 
             bool HasMods = HasFracturedMods || HasExplicitMods || HasCraftedMods || HasVeiledMods || IsMirrored || IsUnidentified || IsCorrupted;
 
-            if (Properties != null && (HasRequirements || HasEnchantMods || HasImplicitMods || HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            if (Properties != null && (HasRequirements || HasEnchantMods || HasImplicitMods || HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
             {
                 this.SeparateProperties = true;
             }
 
-            if (HasRequirements && (HasEnchantMods || HasImplicitMods || HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            if (HasRequirements && (HasEnchantMods || HasImplicitMods || HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
             {
                 this.SeparateRequirements = true;
             }
 
-            if (HasEnchantMods && (HasImplicitMods || HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            if (HasEnchantMods && (HasImplicitMods || HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
             {
                 this.SeparateEnchantMods = true;
             }
 
-            if (HasImplicitMods && (HasMods || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            if (HasImplicitMods && (HasMods || HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
             {
                 this.SeparateImplicitMods = true;
             }
 
-            if (HasMods && (FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            if (HasMods && (HasMicrotransactions || FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
             {
                 this.SeparateMods = true;
+            }
+
+            if (HasMicrotransactions && (FlavourText != null || DescriptionText != null || IsIncubatorProgressVisible))
+            {
+                this.SeparateMicrotransactions = true;
             }
 
             if (FlavourText != null && (DescriptionText != null || IsIncubatorProgressVisible))

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -197,7 +197,7 @@ namespace Procurement.ViewModel
         private void setGearProperties(Item item, Gear gear)
         {
             this.IsGear = true;
-            this.ItemLevel = string.Format("Item Level : {0}", item.ItemLevel);
+            this.ItemLevel = string.Format("Item Level: {0}", item.ItemLevel);
             this.Requirements = gear.Requirements;
             this.ImplicitMods = gear.Implicitmods;
         }

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -84,7 +84,6 @@ namespace Procurement.ViewModel
                     HasSpace = true;
             }
 
-
             List<IFilter> allfilters = getUserFilter(cleanfilter, OrMatch, HasSpace);
             allfilters.AddRange(categoryFilter);
 

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -172,12 +172,16 @@ namespace Procurement.ViewModel
                     (item.TabItem.Content as UIElement).Visibility = Visibility.Visible;
                 }
             }
-            if ((stashView.tabControl.SelectedItem as UIElement).Visibility == Visibility.Collapsed)
+            if (selectedTab.Visibility == Visibility.Collapsed)
             {
                 var first = tabsAndContent.Find(w => w.TabItem.Visibility == Visibility.Visible);
                 if (first != null)
                     first.TabItem.IsSelected = true;
             }
+			else
+			{
+			    selectedTab.BringIntoView();
+			}
         }
 
         public bool LoggedIn { get { return !ApplicationState.Model.Offline; } }

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -118,7 +118,7 @@ namespace Procurement.ViewModel
                                       .Select((element, index) => index % 2 == 0
                                           ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
                                           : new string[] { element })
-                                      .SelectMany(element => element).ToList();
+                                      .SelectMany(element => element).Distinct().ToList();
 
                     if (words?.Count > 0)
                         filterlists.Add(words);
@@ -130,10 +130,12 @@ namespace Procurement.ViewModel
 
                 foreach (var word in words)
                 {
+                    var filterlist = new List<String>();
+
                     if (!ContainsSpace)
                     {
                         if (!string.IsNullOrEmpty(word.Trim('"')))
-                            filterlists.Add(new List<string> { word.Trim('"') });
+                            filterlist.Add(word.Trim('"'));
                     }
                     else
                     {
@@ -141,11 +143,14 @@ namespace Procurement.ViewModel
                                          .Select((element, index) => index % 2 == 0
                                              ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
                                              : new string[] { element })
-                                         .SelectMany(element => element).ToList();
+                                         .SelectMany(element => element).Distinct().ToList();
 
                         if (words1?.Count > 0)
-                            filterlists.Add(words1);
+                            filterlist = words1;
                     }
+
+                    if (!filterlists.Any(list => (list.Count == filterlist.Count) && !list.Except(filterlist).Any()))
+                        filterlists.Add(filterlist);
                 }
             }
 

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -57,31 +57,50 @@ namespace Procurement.ViewModel
 
                 cleanfilter = cleanfilter.Replace(" or ", "|");
 
-                if (cleanfilter.StartsWith("|"))
-                    cleanfilter = cleanfilter.Substring(1);
+                if (cleanfilter.Contains("no pr"))   // no price
+                {
+                    cleanfilter = cleanfilter.Replace(" no pr", " -pr");
+                    cleanfilter = cleanfilter.Replace("|no pr", "|-pr");
 
-                if (cleanfilter.EndsWith("|"))
-                    cleanfilter = cleanfilter.Remove(cleanfilter.Length - 1);
+                    if (cleanfilter.StartsWith("no pr"))
+                        cleanfilter = "-" + cleanfilter.Substring(3);
+                }
 
-                cleanfilter = cleanfilter.Replace(" |", "|").Replace("| ", "|");
+                if (cleanfilter.Contains("not "))
+                {
+                    cleanfilter = cleanfilter.Replace(" not ", " -");
+                    cleanfilter = cleanfilter.Replace("|not ", "|-");
 
-                cleanfilter = cleanfilter.Replace(" not ", " -");
-                cleanfilter = cleanfilter.Replace("|not ", "|-");
+                    if (cleanfilter.StartsWith("not "))
+                        cleanfilter = "-" + cleanfilter.Substring(4);
+                }
 
-                if (cleanfilter.StartsWith("not "))
-                    cleanfilter = "-" + cleanfilter.Substring(4);
+                if (cleanfilter.Contains("-\""))
+                {
+                    cleanfilter = cleanfilter.Replace(" -\"", " \"-");
+                    cleanfilter = cleanfilter.Replace("|-\"", "|\"-");
 
-                cleanfilter = cleanfilter.Replace(" -\"", " \"-");
-                cleanfilter = cleanfilter.Replace("|-\"", "|\"-");
-
-                if (cleanfilter.StartsWith("-\""))
-                    cleanfilter = "\"-" + cleanfilter.Substring(2);
+                    if (cleanfilter.StartsWith("-\""))
+                        cleanfilter = "\"-" + cleanfilter.Substring(2);
+                }
 
                 if (cleanfilter.Contains('|'))
-                    ContainsOr = true;
+                {
+                    cleanfilter = cleanfilter.Replace(" |", "|").Replace("| ", "|");
+
+                    cleanfilter = cleanfilter.Trim('|');
+
+                    if (cleanfilter.Contains('|'))
+                        ContainsOr = true;
+                }
 
                 if (cleanfilter.Contains(' '))
-                    ContainsSpace = true;
+                {
+                    cleanfilter = cleanfilter.Trim();
+
+                    if (cleanfilter.Contains(' '))
+                        ContainsSpace = true;
+                }
             }
 
             var filterlists = new List<List<String>>();

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -177,7 +177,7 @@ namespace Procurement.ViewModel
 
             configuredOrbType = OrbType.Chaos;
             string currencyDistributionMetric = Settings.UserSettings["CurrencyDistributionMetric"];
-            if (currencyDistributionMetric.ToLower() == "count")
+            if (currencyDistributionMetric.ToLowerInvariant() == "count")
                 currencyDistributionUsesCount = true;
             else
                 configuredOrbType = (OrbType)Enum.Parse(typeof(OrbType), currencyDistributionMetric);

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -172,9 +172,12 @@ namespace Procurement.ViewModel
                     (item.TabItem.Content as UIElement).Visibility = Visibility.Visible;
                 }
             }
-            var first = tabsAndContent.Find(w => w.TabItem.Visibility == Visibility.Visible);
-            if (first != null)
-                first.TabItem.IsSelected = true;
+            if ((stashView.tabControl.SelectedItem as UIElement).Visibility == Visibility.Collapsed)
+            {
+                var first = tabsAndContent.Find(w => w.TabItem.Visibility == Visibility.Visible);
+                if (first != null)
+                    first.TabItem.IsSelected = true;
+            }
         }
 
         public bool LoggedIn { get { return !ApplicationState.Model.Offline; } }

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -45,40 +45,45 @@ namespace Procurement.ViewModel
 
         private void processFilter()
         {
-            string cleanfilter = filter.ToLowerInvariant();
-
-            cleanfilter = Regex.Replace(cleanfilter, @"\s+", " ");
-
-            cleanfilter = cleanfilter.Replace(" or ", "|");
-
-            if (cleanfilter.StartsWith("|"))
-                cleanfilter = cleanfilter.Substring(1);
-
-            if (cleanfilter.EndsWith("|"))
-                cleanfilter = cleanfilter.Remove(cleanfilter.Length - 1);
-
-            cleanfilter = cleanfilter.Replace(" |", "|").Replace("| ", "|");
-
-            cleanfilter = cleanfilter.Replace(" not ", " -");
-            cleanfilter = cleanfilter.Replace("|not ", "|-");
-
-            if (cleanfilter.StartsWith("not "))
-                cleanfilter = "-" + cleanfilter.Substring(4);
-
-            cleanfilter = cleanfilter.Replace(" -\"", " \"-");
-            cleanfilter = cleanfilter.Replace("|-\"", "|\"-");
-
-            if (cleanfilter.StartsWith("-\""))
-                cleanfilter = "\"-" + cleanfilter.Substring(2);
-
+            string cleanfilter = null;
             bool OrMatch = false;
             bool HasSpace = false;
 
-            if (cleanfilter.Contains('|'))
-                OrMatch = true;
+            if (!string.IsNullOrEmpty(filter))
+            {
+                cleanfilter = filter.ToLowerInvariant();
 
-            if (cleanfilter.Contains(' '))
-                HasSpace = true;
+                cleanfilter = Regex.Replace(cleanfilter, @"\s+", " ");
+
+                cleanfilter = cleanfilter.Replace(" or ", "|");
+
+                if (cleanfilter.StartsWith("|"))
+                    cleanfilter = cleanfilter.Substring(1);
+
+                if (cleanfilter.EndsWith("|"))
+                    cleanfilter = cleanfilter.Remove(cleanfilter.Length - 1);
+
+                cleanfilter = cleanfilter.Replace(" |", "|").Replace("| ", "|");
+
+                cleanfilter = cleanfilter.Replace(" not ", " -");
+                cleanfilter = cleanfilter.Replace("|not ", "|-");
+
+                if (cleanfilter.StartsWith("not "))
+                    cleanfilter = "-" + cleanfilter.Substring(4);
+
+                cleanfilter = cleanfilter.Replace(" -\"", " \"-");
+                cleanfilter = cleanfilter.Replace("|-\"", "|\"-");
+
+                if (cleanfilter.StartsWith("-\""))
+                    cleanfilter = "\"-" + cleanfilter.Substring(2);
+
+                if (cleanfilter.Contains('|'))
+                    OrMatch = true;
+
+                if (cleanfilter.Contains(' '))
+                    HasSpace = true;
+            }
+
 
             List<IFilter> allfilters = getUserFilter(cleanfilter, OrMatch, HasSpace);
             allfilters.AddRange(categoryFilter);

--- a/Procurement/ViewModel/TabViewModel/StashViewModel.cs
+++ b/Procurement/ViewModel/TabViewModel/StashViewModel.cs
@@ -178,10 +178,10 @@ namespace Procurement.ViewModel
                 if (first != null)
                     first.TabItem.IsSelected = true;
             }
-			else
-			{
-			    selectedTab.BringIntoView();
-			}
+            else
+            {
+                selectedTab.BringIntoView();
+            }
         }
 
         public bool LoggedIn { get { return !ApplicationState.Model.Offline; } }


### PR DESCRIPTION
On Search box, you can now search directly inside mods or texts of items or socketed items (including rarity, properties, requirements, incubation details, description, flavour text, prophecies, cards, gems, item prices, item notes etc.) along with item names and types, autocomplete behavior is unchanged. Similar to in-game stash search though it is much faster and searches all stashes. Search features are detailed on the second comment.

- Replaced Contains with ContainsOrdinal on autocomplete box and replaced ToLower with ToLowerInvariant to fix issues on some system locales.
- Added 250ms delay before search to prevent slowdown while typing.
- Added red "Unidentified" to item hover for unidentified items (which was originally on a different PR).
- Added ":" next to property names in NamePlusValueStrategy to match item hovers in the game.
- Formatted properties on resonators to remove the `<unmet>` color code from item hover and color the number red.
- Added item level for full bestiary orbs and incubators on item hover.
- Added item level, requirements and implicit mods to abyss jewels on item hover which were missing.
- Added separator logic to only add a separator to itemhover when needed.
- Separators now use a different brush depending on item type/rarity.
- Added VisibilityConverter for item properties on itemhover to remove unnecessary line.
- Formatted divination card and flavour texts to remove color/size codes from item hover and to properly color the texts, `<default>` color code used to appear on flavour text of unique items that can be upgraded with a vial or the altar of sacrifice.
- Added missing utility mods for utility flasks on item hover.
- Gem experience and incubation numbers are separated on thousands (like "," or ".") depending on system locale. Game also seems to use thousand separators depending on system locale.
- Improved the gem experience and incubation progress bars to look more like the game's bars, also the progress bar wasn't visible on some systems which is now fixed.
- Full set of divination cards now show a blue stack size in stash like the game does.
- Updated ItemHoverImage, saved images now contain item typeline in the file name which prevents unnamed images for normal or non-gear items.
- Added implicit mods for blighted maps on itemhover.
- All of these changes are taken into account for search filter, additionally searching for color codes (like currency, gem, magic, prophecy, rare, unique, white) will match the relevant divination cards.

- On Advanced Search, filter will now also match your searches with the filter help text.

Some example matches for advanced search filter:
legion - > Incubators
bestiary -> Captured Beasts
normal -> Craftables
chest -> BodyArmor
temple -> Incursion Vials
upgrade -> Fated Uniques, Incursion Vials
prophecy -> Fated Uniques
gear -> lists filters for each gear type
increased -> shows extra mod filters which doesn't have the word "increased" on visible name

Feel free to suggest any improvements or additions