### PR TITLE
Support for unidentified and corrupted items

### DIFF
--- a/Procurement/Controls/ItemHover.xaml
+++ b/Procurement/Controls/ItemHover.xaml
@@ -459,6 +459,20 @@
                         FontFamily="../Resources/#Fontin SmallCaps"
                         Foreground="#960003"
                         Padding="10 0 10 5"
+                        Text="Unidentified"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{Binding IsUnidentified,
+                                                    Converter={StaticResource bc},
+                                                    ConverterParameter=CollapseWhenFalse}" />
+
+                    <TextBlock Width="{Binding Path=ActualWidth,
+                                               ElementName=ItemHeader,
+                                               Mode=OneWay}"
+                        HorizontalAlignment="Center"
+                        FontFamily="../Resources/#Fontin SmallCaps"
+                        Foreground="#960003"
+                        Padding="10 0 10 5"
                         Text="Corrupted"
                         TextAlignment="Center"
                         TextWrapping="Wrap"
@@ -469,7 +483,7 @@
                     <Border Margin="0 0 0 5"
                             BorderBrush="{StaticResource SeperatorBrush}"
                             BorderThickness="1"
-                            Visibility="{Binding IsCorrupted,
+                            Visibility="{Binding IsCorruptedOrUnidentified,
                                                  Converter={StaticResource VisibilityConverter},
                                                  ConverterParameter=CollapseWhenFalse}" />
 

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -196,6 +196,7 @@
     <Compile Include="ViewModel\Filters\ForumExport\FullBestiaryOrbFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\GearSearchFilters.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\GemLevelFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\IdentifiedItemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\IncreasedDamageFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\IncursionVialsFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\LeagestoneFilter.cs" />
@@ -214,6 +215,9 @@
     <Compile Include="ViewModel\Filters\ForumExport\SixLink.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\SixRedSockets.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\SocketColourFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\CorruptedItemFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\UncorruptedItemFilter.cs" />
+    <Compile Include="ViewModel\Filters\ForumExport\UnidentifiedItemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\UnknownItemFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\ScarabFilter.cs" />
     <Compile Include="ViewModel\Filters\ForumExport\VeiledModFilter.cs" />

--- a/Procurement/ViewModel/Filters/ForumExport/CorruptedItemFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/CorruptedItemFilter.cs
@@ -1,0 +1,44 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class CorruptedItemFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public string Keyword
+        {
+            get
+            {
+                return "Corrupted Items";
+            }
+        }
+
+        public string Help
+        {
+            get
+            {
+                return "Corrupted Items";
+            }
+        }
+
+        public FilterGroup Group
+        {
+            get
+            {
+                return FilterGroup.Default;
+            }
+        }
+
+        public bool Applicable(Item item)
+        {
+            return item.Corrupted;
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/IdentifiedItemFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/IdentifiedItemFilter.cs
@@ -1,0 +1,51 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class IdentifiedItemFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public string Keyword
+        {
+            get
+            {
+                return "Identified Items";
+            }
+        }
+
+        public string Help
+        {
+            get
+            {
+                return "Identified Items";
+            }
+        }
+
+        public FilterGroup Group
+        {
+            get
+            {
+                return FilterGroup.Default;
+            }
+        }
+
+        public bool Applicable(Item item)
+        {
+            if (item.TypeLine.Contains("Sacrifice at ") || item.TypeLine.Contains("Mortal ") || item.TypeLine.Contains(" Key") || item.TypeLine.Contains("Fragment of the ") || item.TypeLine.Contains(" Breachstone"))
+                return false;
+
+            if (item is Map && item.Identified)
+                return true;
+
+            Gear gear = item as Gear;
+            return gear != null && gear.Identified && !(gear.MaxStackSize > 0);
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/UncorruptedItemFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/UncorruptedItemFilter.cs
@@ -1,0 +1,51 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class UncorruptedItemFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public string Keyword
+        {
+            get
+            {
+                return "Uncorrupted Items";
+            }
+        }
+
+        public string Help
+        {
+            get
+            {
+                return "Uncorrupted Items";
+            }
+        }
+
+        public FilterGroup Group
+        {
+            get
+            {
+                return FilterGroup.Default;
+            }
+        }
+
+        public bool Applicable(Item item)
+        {
+            if (item.TypeLine.Contains("Sacrifice at ") || item.TypeLine.Contains("Mortal ") || item.TypeLine.Contains(" Key") || item.TypeLine.Contains("Fragment of the ") || item.TypeLine.Contains(" Breachstone"))
+                return false;
+
+            if ((item is Map || item is Gem) && !item.Corrupted)
+                return true;
+
+            Gear gear = item as Gear;
+            return gear != null && !gear.Corrupted && !(gear.MaxStackSize > 0);
+        }
+    }
+}

--- a/Procurement/ViewModel/Filters/ForumExport/UnidentifiedItemFilter.cs
+++ b/Procurement/ViewModel/Filters/ForumExport/UnidentifiedItemFilter.cs
@@ -1,0 +1,44 @@
+﻿using POEApi.Model;
+
+namespace Procurement.ViewModel.Filters.ForumExport
+{
+    public class UnidentifiedItemFilter : IFilter
+    {
+        public bool CanFormCategory
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public string Keyword
+        {
+            get
+            {
+                return "Unidentified Items";
+            }
+        }
+
+        public string Help
+        {
+            get
+            {
+                return "Unidentified Items";
+            }
+        }
+
+        public FilterGroup Group
+        {
+            get
+            {
+                return FilterGroup.Default;
+            }
+        }
+
+        public bool Applicable(Item item)
+        {
+            return !item.Identified;
+        }
+    }
+}

--- a/Procurement/ViewModel/ItemHoverViewModel.cs
+++ b/Procurement/ViewModel/ItemHoverViewModel.cs
@@ -26,6 +26,8 @@ namespace Procurement.ViewModel
         public string DescriptionText { get; private set; }
         public string SecondaryDescriptionText { get; private set; }
         public bool IsCorrupted { get; private set; }
+        public bool IsUnidentified { get; private set; }
+        public bool IsCorruptedOrUnidentified { get; private set; }
         public List<string> Microtransactions { get; private set; }
         public bool HasMicrotransactions { get; private set; }
         public List<string> EnchantMods { get; private set; }
@@ -96,6 +98,9 @@ namespace Procurement.ViewModel
             this.DescriptionText = item.DescrText;
 
             this.IsCorrupted = item.Corrupted;
+            this.IsUnidentified = !item.Identified;
+            if (item.Corrupted || !item.Identified)
+                this.IsCorruptedOrUnidentified = true;
 
             this.Microtransactions = item.Microtransactions;
             this.HasMicrotransactions = item.Microtransactions.Count > 0;


### PR DESCRIPTION
Added "Unidentified" text for unidentified items, added filters for unidentified and corrupted items and ensured "unidentified corrupted" maps look same as in-game. closes #995

Added identified and uncorrupted item filters which only return maps and gear which can be identified or corrupted