### PR TITLE
TEMP: Switch to a patched CloudflareSolverRe package.

### DIFF
--- a/POEApi.Infrastructure/POEApi.Infrastructure.csproj
+++ b/POEApi.Infrastructure/POEApi.Infrastructure.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>POEApi.Infrastructure</RootNamespace>
     <AssemblyName>POEApi.Infrastructure</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>POEApi.Model</RootNamespace>
     <AssemblyName>POEApi.Model</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -58,7 +58,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Interactive.Async, Version=3.2.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Interactive.Async.3.2.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.2.0\lib\net46\System.Interactive.Async.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -170,12 +170,12 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <Protobuf Include="ItemFilterConfig.proto" />
     <None Include="app.config" />
     <None Include="ItemFilterConfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/POEApi.Model/POEApi.Model.csproj
+++ b/POEApi.Model/POEApi.Model.csproj
@@ -171,6 +171,7 @@
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="ItemFilterConfig.proto" />
+    <None Include="app.config" />
     <None Include="ItemFilterConfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/POEApi.Model/app.config
+++ b/POEApi.Model/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/POEApi.Model/app.config
+++ b/POEApi.Model/app.config
@@ -6,6 +6,34 @@
         <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/POEApi.Model/packages.config
+++ b/POEApi.Model/packages.config
@@ -6,5 +6,5 @@
   <package id="Grpc.Core.Api" version="1.21.0" targetFramework="net45" />
   <package id="Grpc.Tools" version="1.21.0" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="System.Interactive.Async" version="3.2.0" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.2.0" targetFramework="net45" requireReinstallation="true" />
 </packages>

--- a/POEApi.Model/packages.config
+++ b/POEApi.Model/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.Protobuf" version="3.8.0" targetFramework="net45" />
-  <package id="Grpc" version="1.21.0" targetFramework="net45" />
-  <package id="Grpc.Core" version="1.21.0" targetFramework="net45" />
-  <package id="Grpc.Core.Api" version="1.21.0" targetFramework="net45" />
-  <package id="Grpc.Tools" version="1.21.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="System.Interactive.Async" version="3.2.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="Google.Protobuf" version="3.8.0" targetFramework="net462" />
+  <package id="Grpc" version="1.21.0" targetFramework="net462" />
+  <package id="Grpc.Core" version="1.21.0" targetFramework="net462" />
+  <package id="Grpc.Core.Api" version="1.21.0" targetFramework="net462" />
+  <package id="Grpc.Tools" version="1.21.0" targetFramework="net462" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="System.Interactive.Async" version="3.2.0" targetFramework="net462" />
 </packages>

--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -35,19 +35,76 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CloudflareSolverRe, Version=1.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.6.2\lib\netstandard1.1\CloudflareSolverRe.dll</HintPath>
+    <Reference Include="CloudflareSolverRe, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.7\lib\netstandard1.3\CloudflareSolverRe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Jint, Version=0.0.0.0, Culture=neutral, PublicKeyToken=2e92ba9c8d81157f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Jint.2.11.58\lib\net451\Jint.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -70,6 +127,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -36,7 +36,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CloudflareSolverRe, Version=1.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CloudflareSolverRe.1.0.6\lib\netstandard1.1\CloudflareSolverRe.dll</HintPath>
+      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.6.1\lib\netstandard1.1\CloudflareSolverRe.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CloudflareSolverRe, Version=1.0.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.6.1\lib\netstandard1.1\CloudflareSolverRe.dll</HintPath>
+      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.6.2\lib\netstandard1.1\CloudflareSolverRe.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>POEApi.Transport</RootNamespace>
     <AssemblyName>POEApi.Transport</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CloudflareSolverRe, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.7.2\lib\netstandard1.3\CloudflareSolverRe.dll</HintPath>
+      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.7.3\lib\netstandard1.3\CloudflareSolverRe.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Jint, Version=0.0.0.0, Culture=neutral, PublicKeyToken=2e92ba9c8d81157f, processorArchitecture=MSIL">

--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CloudflareSolverRe, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.7\lib\netstandard1.3\CloudflareSolverRe.dll</HintPath>
+      <HintPath>..\packages\CloudflareSolverReNgosang.1.0.7.2\lib\netstandard1.3\CloudflareSolverRe.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Jint, Version=0.0.0.0, Culture=neutral, PublicKeyToken=2e92ba9c8d81157f, processorArchitecture=MSIL">

--- a/POEApi.Transport/POEApi.Transport.csproj
+++ b/POEApi.Transport/POEApi.Transport.csproj
@@ -62,12 +62,23 @@
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Diagnostics.Tracing, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.Tracing.4.3.0\lib\net462\System.Diagnostics.Tracing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
@@ -81,12 +92,31 @@
       <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.4.3.0\lib\net462\System.Runtime.InteropServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
@@ -112,6 +142,10 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CachedTransport.cs" />

--- a/POEApi.Transport/app.config
+++ b/POEApi.Transport/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/POEApi.Transport/app.config
+++ b/POEApi.Transport/app.config
@@ -6,6 +6,34 @@
         <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -2,50 +2,50 @@
 <packages>
   <package id="CloudflareSolverReNgosang" version="1.0.7" targetFramework="net462" />
   <package id="Jint" version="2.11.58" targetFramework="net462" />
-  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
-  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
-  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net462" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net462" />
   <package id="System.Console" version="4.3.0" targetFramework="net462" />
-  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
-  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
-  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net462" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net462" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net462" />
   <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net462" />
-  <package id="System.IO" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.IO" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net462" />
   <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net462" />
   <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net462" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
-  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net462" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net462" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
-  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
-  <package id="System.Reflection" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
-  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net462" />
-  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
-  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net462" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net462" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
-  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net462" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net462" />
 </packages>

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CloudflareSolverRe" version="1.0.6" targetFramework="net45" />
+  <package id="CloudflareSolverReNgosang" version="1.0.6.1" targetFramework="net45" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -1,20 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CloudflareSolverReNgosang" version="1.0.6.2" targetFramework="net45" />
+  <package id="CloudflareSolverReNgosang" version="1.0.7" targetFramework="net462" />
+  <package id="Jint" version="2.11.58" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net462" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Console" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net462" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net462" />
   <package id="System.IO" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net462" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Linq" version="4.3.0" targetFramework="net45" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
   <package id="System.Net.Http" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net462" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
@@ -22,14 +32,20 @@
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net462" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net462" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CloudflareSolverReNgosang" version="1.0.7.2" targetFramework="net462" />
+  <package id="CloudflareSolverReNgosang" version="1.0.7.3" targetFramework="net462" />
   <package id="Jint" version="2.11.58" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CloudflareSolverReNgosang" version="1.0.6.1" targetFramework="net45" />
+  <package id="CloudflareSolverReNgosang" version="1.0.6.2" targetFramework="net45" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="System.Collections" version="4.3.0" targetFramework="net45" />

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -7,22 +7,22 @@
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
-  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
-  <package id="System.IO" version="4.3.0" targetFramework="net45" />
-  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Linq" version="4.3.0" targetFramework="net45" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
-  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
-  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
@@ -30,6 +30,6 @@
   <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading" version="4.3.0" targetFramework="net45" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" requireReinstallation="true" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/POEApi.Transport/packages.config
+++ b/POEApi.Transport/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CloudflareSolverReNgosang" version="1.0.7" targetFramework="net462" />
+  <package id="CloudflareSolverReNgosang" version="1.0.7.2" targetFramework="net462" />
   <package id="Jint" version="2.11.58" targetFramework="net462" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />

--- a/Procurement/Procurement.csproj
+++ b/Procurement/Procurement.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Procurement</RootNamespace>
     <AssemblyName>Procurement</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Procurement/RelayCommand.cs
+++ b/Procurement/RelayCommand.cs
@@ -6,8 +6,14 @@ namespace Procurement.View.ViewModel
 {
     public class RelayCommand : ICommand
     {
-        readonly Action<object> _execute;
-        readonly Predicate<object> _canExecute;
+        #region Fields
+
+        readonly Action<object> execute;
+        readonly Predicate<object> canExecute;
+
+        #endregion
+
+        #region Constructors
 
         public RelayCommand(Action<object> execute)
             : this(execute, null)
@@ -19,14 +25,17 @@ namespace Procurement.View.ViewModel
             if (execute == null)
                 throw new ArgumentNullException("execute");
 
-            _execute = execute;
-            _canExecute = canExecute;
+            this.execute = execute;
+            this.canExecute = canExecute;
         }
+        #endregion
+
+        #region ICommand Members
 
         [DebuggerStepThrough]
         public bool CanExecute(object parameter)
         {
-            return _canExecute == null ? true : _canExecute(parameter);
+            return canExecute == null ? true : canExecute(parameter);
         }
 
         public event EventHandler CanExecuteChanged
@@ -37,7 +46,9 @@ namespace Procurement.View.ViewModel
 
         public void Execute(object parameter)
         {
-            _execute(parameter);
+            execute(parameter);
         }
+
+        #endregion
     }
 }

--- a/Procurement/app.config
+++ b/Procurement/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/Procurement/app.config
+++ b/Procurement/app.config
@@ -7,6 +7,34 @@
         <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Procurement/app.config
+++ b/Procurement/app.config
@@ -1,3 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Procurement/packages.config
+++ b/Procurement/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RelayCommand" version="1.0.2" targetFramework="net45" />
-  <package id="WPFToolkit" version="3.5.50211.1" targetFramework="net40-client" />
+  <package id="RelayCommand" version="1.0.2" targetFramework="net462" />
+  <package id="WPFToolkit" version="3.5.50211.1" targetFramework="net462" />
 </packages>

--- a/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
+++ b/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="UnknownItemTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="TestData\SampleFragmentStash.json" />
     <None Include="TestData\SampleCharacterExpiredName.json" />

--- a/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
+++ b/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
@@ -42,9 +42,11 @@
     </Reference>
     <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions.Core, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.5.22.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.5.22\lib\net45\Moq.dll</HintPath>

--- a/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
+++ b/Tests/POEApi.Model.Tests/POEApi.Model.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>POEApi.Model.Tests</RootNamespace>
     <AssemblyName>POEApi.Model.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Tests/POEApi.Model.Tests/app.config
+++ b/Tests/POEApi.Model.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/POEApi.Model.Tests/app.config
+++ b/Tests/POEApi.Model.Tests/app.config
@@ -6,6 +6,34 @@
         <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Tests/POEApi.Model.Tests/packages.config
+++ b/Tests/POEApi.Model.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="FluentAssertions" version="4.19.4" targetFramework="net45" />
-  <package id="Moq" version="4.5.22" targetFramework="net45" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net462" />
+  <package id="FluentAssertions" version="4.19.4" targetFramework="net462" />
+  <package id="Moq" version="4.5.22" targetFramework="net462" />
 </packages>

--- a/Tests/POEApi.TestHelpers/POEApi.TestHelpers.csproj
+++ b/Tests/POEApi.TestHelpers/POEApi.TestHelpers.csproj
@@ -41,7 +41,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/POEApi.TestHelpers/POEApi.TestHelpers.csproj
+++ b/Tests/POEApi.TestHelpers/POEApi.TestHelpers.csproj
@@ -56,6 +56,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/POEApi.TestHelpers/POEApi.TestHelpers.csproj
+++ b/Tests/POEApi.TestHelpers/POEApi.TestHelpers.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>POEApi.TestHelpers</RootNamespace>
     <AssemblyName>POEApi.TestHelpers</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Tests/POEApi.TestHelpers/app.config
+++ b/Tests/POEApi.TestHelpers/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/POEApi.TestHelpers/app.config
+++ b/Tests/POEApi.TestHelpers/app.config
@@ -6,6 +6,34 @@
         <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Tests/POEApi.TestHelpers/packages.config
+++ b/Tests/POEApi.TestHelpers/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
 </packages>

--- a/Tests/Procurement.Tests/Procurement.Tests.csproj
+++ b/Tests/Procurement.Tests/Procurement.Tests.csproj
@@ -50,7 +50,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Procurement.Tests/Procurement.Tests.csproj
+++ b/Tests/Procurement.Tests/Procurement.Tests.csproj
@@ -43,7 +43,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/Tests/Procurement.Tests/Procurement.Tests.csproj
+++ b/Tests/Procurement.Tests/Procurement.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Procurement.Tests</RootNamespace>
     <AssemblyName>Procurement.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Tests/Procurement.Tests/Procurement.Tests.csproj
+++ b/Tests/Procurement.Tests/Procurement.Tests.csproj
@@ -78,6 +78,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/Procurement.Tests/app.config
+++ b/Tests/Procurement.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/Procurement.Tests/app.config
+++ b/Tests/Procurement.Tests/app.config
@@ -6,6 +6,34 @@
         <assemblyIdentity name="System.Console" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Tests/Procurement.Tests/packages.config
+++ b/Tests/Procurement.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.19.4" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" requireReinstallation="true" />
+  <package id="FluentAssertions" version="4.19.4" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net462" />
 </packages>

--- a/Tests/Procurement.Tests/packages.config
+++ b/Tests/Procurement.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.19.4" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" requireReinstallation="true" />
 </packages>


### PR DESCRIPTION
This package is a fork of the "official" CloudflareSolverRe, but it includes a fix for a Cloudflare change that was just introduced in the last day or so.

We should probably not merge this PR, and instead wait for the package we are using already to merge this patch.  In the meantime, however, this PR can provide a temporary working version of Procurement.

This PR also updates the Procurement projects to the .NET Framework 4.6.2 (from 4.5).  Newer versions of the CloudflareSolverRe package requires the .NET Framework 4.6.

**EDIT:** The latest version of this patch is from **2020.05.28**.  It can be downloaded [here](https://ci.appveyor.com/api/buildjobs/pcge9o9kjff03knt/artifacts/Procurement%2Fbin%2FProcurement.zip).  This download link is available for six months, until 2020.11.28.