### PR TITLE
Gracefully handle item Property with one part.

### DIFF
--- a/Procurement/ViewModel/DisplayModeStrategy/StringFormatStrategy.cs
+++ b/Procurement/ViewModel/DisplayModeStrategy/StringFormatStrategy.cs
@@ -18,6 +18,12 @@ namespace Procurement.ViewModel
             var parts = property.Name.Split('%');
             ret.Inlines.Add(new Run(parts[0]) { Foreground = Brushes.Gray });
             ret.Inlines.Add(new Run(property.Values[0].Item1) { Foreground = Brushes.White } );
+
+            // Heist contracts (and possibly other items now, too) appear to
+            // have only one part parsed from the property.
+            if (parts.Length == 1)
+                return ret;
+
             ret.Inlines.Add(new Run(parts[1].Substring(1)) { Foreground = Brushes.Gray });
 
             if (property.Values.Count == 1)


### PR DESCRIPTION
Heist blueprints, as well as possibly some older items, such as rares with certain affixes, only have one "part" parsed from their
properties.  This change has the function creating a Paragraph from this Property return early in this situation, instead of crashing.  It probably does not format the Paragraph correctly, based on the new Property behavior.